### PR TITLE
Add ansible roles to setup xdma + pcimem

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,10 +56,26 @@ The specification for eid-hermes is located in Markdown files in the
 * **[eid-hermes-interface.md][10]** - The PCIe register interface to the
     eid-hermes device and the overall BAR layout.
 
+# Dependencies and host configuration
+
+Eid-hermes uses the [XDMA][11] kernel module for data transfer between the host
+and the device. That driver needs to be patched to accept the Hermes PCI
+device/vendor ID.
+
+To facilitate installation, an [Ansible][12] playbook is provided, which also
+installs some helper programs, such as [pcimem][13].
+
+To run it, first install ansible then run:
+
+```
+cd ansible
+ansible-playbook hermes.yml -K
+```
+
 # Licensing
 
 Where possible the code in this repository is licensed under the
-[Apache License, Version 2.0][11]. This is a permissive license allowing
+[Apache License, Version 2.0][14]. This is a permissive license allowing
 anyone to use this code, even for commercial purposes, if they so
 wish. Please refer to the full text of the license for more
 information.
@@ -67,9 +83,9 @@ information.
 # Contributing
 
 Contributions in the form of pull-requests are most welcome. The
-upstream version of this repo is located at [this link][12]. Note that
+upstream version of this repo is located at [this link][15]. Note that
 only PGP signed commits will be accepted so please setup [PGP
-signing][13] in order to commit to this project.
+signing][16] in order to commit to this project.
 
 [1]: https://www.eideticom.com/
 [2]: https://github.com/iovisor/bpf-docs/blob/master/eBPF.md
@@ -81,6 +97,9 @@ signing][13] in order to commit to this project.
 [8]: https://www.snia.org/computational
 [9]: specs/eid-hermes-theory-of-operation.md
 [10]: specs/eid-hermes-interface.md
-[11]: https://www.apache.org/licenses/LICENSE-2.0
-[12]: https://github.com/Eideticom/eid-hermes
-[13]: https://docs.github.com/en/github/authenticating-to-github/signing-commits
+[11]: https://github.com/aws/aws-fpga/tree/master/sdk/linux_kernel_drivers/xdma
+[12]: https://www.ansible.com/
+[13]: https://github.com/billfarrow/pcimem
+[14]: https://www.apache.org/licenses/LICENSE-2.0
+[15]: https://github.com/Eideticom/eid-hermes
+[16]: https://docs.github.com/en/github/authenticating-to-github/signing-commits

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults]
+inventory = inventory
+verbosity = 0

--- a/ansible/hermes.yml
+++ b/ansible/hermes.yml
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2020. Eidetic Communications Inc.
+# All rights reserved.
+#
+
+# This playbook can be used to test a Hermes device. It will download all
+# necessary software and run some tests.
+#
+# Note that currently this must be run directly inside the QEMU guest. We plan
+# to add support for running from the host in the future.
+
+- name: Test Hermes
+  hosts: localhost
+  roles:
+    - role: pcimem
+    - role: xdma
+    - role: xdma_test

--- a/ansible/inventory
+++ b/ansible/inventory
@@ -1,0 +1,2 @@
+[localhost]
+127.0.0.1  ansible_connection=local ansible_python_interpreter=python3

--- a/ansible/roles/pcimem/tasks/main.yml
+++ b/ansible/roles/pcimem/tasks/main.yml
@@ -1,0 +1,43 @@
+#
+# Copyright (c) 2020. Eidetic Communications Inc.
+# All rights reserved.
+#
+
+- name: Check if pcimem is installed
+  stat:
+    path: /usr/local/bin/pcimem
+  register: pcimem_installed
+
+- name: Install pcimem
+  block:
+    - name: Create temporary directory
+      tempfile:
+        state: directory
+      register: tmpdir
+
+    - name: Clone pcimem
+      git:
+        repo: https://github.com/billfarrow/pcimem.git
+        depth: 1
+        recursive: true
+        dest: "{{ tmpdir.path }}"
+        accept_hostkey: yes
+
+    - name: Compile pcimem
+      make:
+        chdir: "{{ tmpdir.path }}"
+
+    - name: Install pcimem
+      become: yes
+      copy:
+        src: "{{ tmpdir.path }}/pcimem"
+        dest: /usr/local/bin/pcimem
+        remote_src: yes
+        mode: 0755
+
+  always:
+    - name: Cleanup
+      file:
+        path: "{{ tmpdir.path }}"
+        state: absent
+  when: not pcimem_installed.stat.exists

--- a/ansible/roles/xdma/tasks/main.yml
+++ b/ansible/roles/xdma/tasks/main.yml
@@ -1,0 +1,48 @@
+#
+# Copyright (c) 2020. Eidetic Communications Inc.
+# All rights reserved.
+#
+
+- name: Install xdma
+  block:
+    - name: Create temporary directory
+      tempfile:
+        state: directory
+      register: tmpdir
+
+    - name: Clone aws-fpga repository
+      git:
+        repo: https://github.com/aws/aws-fpga
+        depth: 1
+        recursive: no
+        dest: "{{ tmpdir.path }}"
+        accept_hostkey: true
+        version: v1.4.17
+
+    - name: Add Hermes to list of devices supported by xdma driver
+      lineinfile:
+        path: "{{ tmpdir.path }}/sdk/linux_kernel_drivers/xdma/xdma_mod.c"
+        insertafter: '.*pci_ids\[\] = {.*'
+        line: '{ PCI_DEVICE(0x1de5, 0x3000), },'
+
+    - name: Compile XDMA driver
+      make:
+        chdir: "{{ tmpdir.path }}/sdk/linux_kernel_drivers/xdma"
+
+    - name: Install XDMA driver
+      become: yes
+      make:
+        target: install
+        chdir: "{{ tmpdir.path }}/sdk/linux_kernel_drivers/xdma"
+
+  always:
+    - name: Cleanup
+      file:
+        path: "{{ tmpdir.path }}"
+        state: absent
+
+- name: Load xdma driver
+  become: yes
+  modprobe:
+    name: xdma
+    state: present

--- a/ansible/roles/xdma_test/files/xdma_test.c
+++ b/ansible/roles/xdma_test/files/xdma_test.c
@@ -1,0 +1,87 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <unistd.h>
+
+#define BUF_SIZE              50 * 4096
+#define OFFSET_IN_FPGA_DRAM   0x10000000
+
+static char *rand_str(char *str, size_t size)  // randomize a string of size <size>
+{
+    const char charset[] = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRTSUVWXYZ1234567890";
+    int i;
+
+    for(i = 0; i < size; i++) {
+        int key = rand() % (int) (sizeof charset - 1);
+        str[i] = charset[key];
+    }
+
+    str[size-1] = '\0';
+    return str;
+}
+
+
+int main()
+{
+    char* srcBuf;
+    char* dstBuf;
+    int read_fd;
+    int write_fd;
+    int i;
+    int ret;
+
+    srcBuf = (char*)malloc(BUF_SIZE * sizeof(char));
+    dstBuf = (char*)malloc(BUF_SIZE * sizeof(char));
+
+    /* Initialize srcBuf */
+    rand_str(srcBuf, BUF_SIZE);
+
+    /* Open a XDMA write channel (Host to Core) */
+    if ((write_fd = open("/dev/xdma0_h2c_0",O_WRONLY)) == -1) {
+        perror("open failed with errno");
+    }
+
+    /* Open a XDMA read channel (Core to Host) */
+    if ((read_fd = open("/dev/xdma0_c2h_0",O_RDONLY)) == -1) {
+        perror("open failed with errno");
+    }
+
+    /* Write the entire source buffer to offset OFFSET_IN_FPGA_DRAM */
+    ret = pwrite(write_fd , srcBuf, BUF_SIZE, OFFSET_IN_FPGA_DRAM);
+    if (ret < 0) {
+        perror("write failed with errno");
+    }
+
+    printf("Tried to write %u bytes, succeeded in writing %u bytes\n", BUF_SIZE, ret);
+    if (BUF_SIZE != ret) {
+        return 1;
+    }
+
+    ret = pread(read_fd, dstBuf, BUF_SIZE, OFFSET_IN_FPGA_DRAM);
+    if (ret < 0) {
+        perror("read failed with errno");
+    }
+
+    printf("Tried reading %u byte, succeeded in read %u bytes\n", BUF_SIZE, ret);
+    if (BUF_SIZE != ret) {
+        return 1;
+    }
+
+    if (close(write_fd) < 0) {
+        perror("write_fd close failed with errno");
+    }
+    if (close(read_fd) < 0) {
+        perror("read_fd close failed with errno");
+    }
+
+    printf("Data read is %s\n", dstBuf);
+
+    if (strncmp(srcBuf, dstBuf, BUF_SIZE)) {
+        printf("Data mismatch\n");
+	return 1;
+    }
+
+    return 0;
+}

--- a/ansible/roles/xdma_test/tasks/main.yml
+++ b/ansible/roles/xdma_test/tasks/main.yml
@@ -1,0 +1,40 @@
+#
+# Copyright (c) 2020. Eidetic Communications Inc.
+# All rights reserved.
+#
+
+- name: Ensure the xdma driver is loaded
+  become: yes
+  modprobe:
+    name: xdma
+    state: present
+
+- name: Compile and run xdma_test
+  block:
+    - name: Create temporary directory
+      tempfile:
+        state: directory
+      register: tmpdir
+
+    - name: Copy xdma_test.c to tmpdir
+      copy:
+        src: xdma_test.c
+        dest: "{{ tmpdir.path }}"
+
+    - name: Compile xdma_test
+      command:
+        cmd: gcc -o xdma_test xdma_test.c
+        chdir: "{{ tmpdir.path }}"
+
+    - name: Run xdma_test
+      become: yes
+      command:
+        cmd: ./xdma_test
+        chdir: "{{ tmpdir.path }}"
+      changed_when: false
+
+  always:
+    - name: Cleanup
+      file:
+        path: "{{ tmpdir.path }}"
+        state: absent


### PR DESCRIPTION
These ansible roles and playbook will install and test the xdma driver, patching it to work with the Hermes vendor ID/device ID.

It also installs [pcimem](https://github.com/billfarrow/pcimem), a tool to read/write BARs.