### PR TITLE
unit_test: add XDMA tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,20 @@ cd ansible
 ansible-playbook hermes.yml -K
 ```
 
+# Testing
+
+We include unit tests on the [tests][15] directory. To run them:
+
+```
+sudo tests/unit_test
+```
+
+You may find the `-v` (verbose) and `-f` (failfast) options useful.
+
 # Licensing
 
 Where possible the code in this repository is licensed under the
-[Apache License, Version 2.0][15]. This is a permissive license allowing
+[Apache License, Version 2.0][16]. This is a permissive license allowing
 anyone to use this code, even for commercial purposes, if they so
 wish. Please refer to the full text of the license for more
 information.
@@ -86,9 +96,9 @@ information.
 # Contributing
 
 Contributions in the form of pull-requests are most welcome. The
-upstream version of this repo is located at [this link][16]. Note that
+upstream version of this repo is located at [this link][17]. Note that
 only PGP signed commits will be accepted so please setup [PGP
-signing][17] in order to commit to this project.
+signing][18] in order to commit to this project.
 
 [1]: https://www.eideticom.com/
 [2]: https://github.com/iovisor/bpf-docs/blob/master/eBPF.md
@@ -104,6 +114,7 @@ signing][17] in order to commit to this project.
 [12]: https://github.com/aws/aws-fpga/tree/master/sdk/linux_kernel_drivers/xdma
 [13]: https://www.ansible.com/
 [14]: https://github.com/billfarrow/pcimem
-[15]: https://www.apache.org/licenses/LICENSE-2.0
-[16]: https://github.com/Eideticom/eid-hermes
-[17]: https://docs.github.com/en/github/authenticating-to-github/signing-commits
+[15]: tests/
+[16]: https://www.apache.org/licenses/LICENSE-2.0
+[17]: https://github.com/Eideticom/eid-hermes
+[18]: https://docs.github.com/en/github/authenticating-to-github/signing-commits

--- a/tests/unit_test
+++ b/tests/unit_test
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+import os
+import random
+import unittest
+
+class XdmaTests(unittest.TestCase):
+    h2c_chnl = '/dev/xdma0_h2c_0'
+    c2h_chnl = '/dev/xdma0_c2h_0'
+    dram_offset = 0x10000000
+
+    def randomBytes(self, count, seed=1):
+        random.seed(seed)
+        return bytes(random.randint(0, 255) for i in range(count))
+
+    def _testXDMA(self, len):
+        src = self.randomBytes(len)
+        with open(self.h2c_chnl, 'wb') as h2c, \
+                open(self.c2h_chnl, 'rb') as c2h:
+
+            h2c.seek(self.dram_offset)
+            write = h2c.write(src)
+            if len == -1:
+                self.fail('Failed to write to ' + self.h2c_chnl)
+
+            c2h.seek(self.dram_offset)
+            dst = c2h.read(len)
+            if dst is None:
+                self.fail('Failed to read from ' + self.c2h_chnl)
+
+            if dst != src:
+                self.fail('Data mismatch')
+
+    def testXDMA_small(self):
+        # uses a single DMA descriptor
+        self._testXDMA(256)
+
+    def testXDMA_medium(self):
+        # DMA descriptors will not cross a 4K address boundary
+        self._testXDMA(16*1024)
+
+    def testXDMA_large(self):
+        # DMA descriptors will cross a 4K address boundary
+        self._testXDMA(1024*1024)
+
+if __name__ == '__main__':
+    unittest.TestProgram(buffer=True, catchbreak=True)


### PR DESCRIPTION
These tests write to the device then read back and check if the data
matches.

Test different buffer sizes to exercise different paths on the device.