### PR TITLE
specs: add BAR0 register for command requests/responses

### DIFF
--- a/specs/eid-hermes-interface.md
+++ b/specs/eid-hermes-interface.md
@@ -31,22 +31,36 @@ BAR0 in an eid-hermes device contains the eid-hermes device registers
 which advertise a range of relevant capabilities to the host. These
 registers are defined in the table below.
 
-|Offset  | Length | Name    | Mode | Value | Description            |
-|--------|--------|---------|------|-------|------------------------|
-| 0x00   | 4      | EHVER   | RO   | 1     | Interface version      |
-| 0x04   | 48     | EHBLD   | RO   | NA    | Build version (git describe) |
-| 0x34   | 1      | EHENG   | RO   | NA    | Number of eBPF Engines |
-| 0x35   | 1      | EHPSLOT | RO   | NA    | Number of program slots   |
-| 0x36   | 1      | EHDSLOT | RO   | NA    | Number of data slots |
-| 0x38   | 4      | EHPSOFF | RO   | NA    | Base address in BAR4 of eBPF program slots |
-| 0x3C   | 4      | EHPSSZE | RO   | NA    | Size of a single program slot |
-| 0x40   | 4      | EHDSOFF | RO   | NA    | Base address in BAR4 of eBPF data slots |
-| 0x44   | 4      | EHDSSZE | RO   | NA    | Size of a single data slot |
+For each eBPF engine (`EHENG`), there is one set of command [request/response
+registers][2] (48 bytes each, starting at offset `0x1000`) and one one-byte
+control register (starting at offset `0x2000`). As noted in the [command
+formats specification][3], these registers are not used for Read/Write
+commands.
+
+|Offset                  | Length | Name         | Mode | Value | Description            |
+|------------------------|--------|--------------|------|-------|------------------------|
+| 0x00                   | 4      | EHVER        | RO   | 1     | Interface version      |
+| 0x04                   | 48     | EHBLD        | RO   | NA    | Build version (git describe) |
+| 0x34                   | 1      | EHENG        | RO   | NA    | Number of eBPF Engines |
+| 0x35                   | 1      | EHPSLOT      | RO   | NA    | Number of program slots |
+| 0x36                   | 1      | EHDSLOT      | RO   | NA    | Number of data slots |
+| 0x38                   | 4      | EHPSOFF      | RO   | NA    | Base address in BAR4 of eBPF program slots |
+| 0x3C                   | 4      | EHPSSZE      | RO   | NA    | Size of a single program slot |
+| 0x40                   | 4      | EHDSOFF      | RO   | NA    | Base address in BAR4 of eBPF data slots |
+| 0x44                   | 4      | EHDSSZE      | RO   | NA    | Size of a single data slot |
+| 0x1000                 | 32     | EHCMDREQ0    | RW   | NA    | Command Request for engine 0 |
+| 0x1020                 | 16     | EHCMDRES0    | RO   | NA    | Command Response for engine 0 |
+| ...                    | ...    | ...          | ...  | ...   | ... |
+| 0x1000 + (EHENG-1)\*48 | 32     | EHCMDREQN-1  | RW   | NA    | Command Request for engine N-1 |
+| 0x1020 + (EHENG-1)\*48 | 16     | EHCMDRESN-1  | RO   | NA    | Command Response for engine N-1 |
+| 0x2000                 | 1      | EHCMDCTRL0   | RW   | NA    | Write 1 to start Command Request 0. Cleared after command finishes |
+| ...                    | ...    | ...          | ...  | ...   | ... |
+| 0x2000 + (EHENG-1)     | 1      | EHCMDCTRLN-1 | RW   | NA    | Write 1 to start Command Request N-1. Cleared after command finishes |
 
 ## BAR2 Layout
 
 The layout of BAR2 follows that of the XDMA IP provided by Xilinx and
-which can be found [here][2] (however note that in this document it
+which can be found [here][4] (however note that in this document it
 refers to BAR1 but we use it in BAR2). This BAR can be used to move
 data from host memory into the eBPF program slots and eBPF data slots
 prior to executing an eBPF program. It is expected that this project
@@ -62,4 +76,6 @@ be p2pdma from other devices which should only target data slots (not
 program slots).
 
 [1]: https://github.com/aws/aws-fpga/blob/master/hdk/docs/AWS_Fpga_Pcie_Memory_Map.md
-[2]: https://www.xilinx.com/support/documentation/ip_documentation/xdma/v4_1/pg195-pcie-dma.pdf
+[2]: eid-hermes-commands-format.md#command-format
+[3]: eid-hermes-commands-format.md#list-of-commands
+[4]: https://www.xilinx.com/support/documentation/ip_documentation/xdma/v4_1/pg195-pcie-dma.pdf


### PR DESCRIPTION
For every eBPF engine (EHENG), we have one set of command
request/response registers (starting at 0x1000) and one one-byte control
register (starting at 0x2000).

The user must write to the command request register, then write to the
corresponding control register, which starts the command. When the
command finishes, the hardware writes to the command response registers
and clears the control register.

Note that the above does not apply to the Write/Read commands, which are
handled by the hermes/xdma driver.

Fixes #16