### PR TITLE
Add read_iter / write_iter 

### DIFF
--- a/examples/iovec.c
+++ b/examples/iovec.c
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright 2020 Eideticom Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ******************************************************************************/
+
+#define _GNU_SOURCE
+
+#include "hermes_uapi.h"
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <sys/ioctl.h>
+#include <sys/uio.h>
+#include <linux/fs.h>
+
+#define BUF_SIZE 1024 * 1024
+
+int main()
+{
+	char *src, *dst, *prog;
+	int hermes_fd;
+	int ret;
+	struct hermes_download_prog_ioctl_argp argp = {
+		.len = BUF_SIZE,
+	};
+	struct iovec iov;
+
+	/* Open device */
+	hermes_fd = open("/dev/hermes0", O_RDWR);
+	if (hermes_fd == -1) {
+		fprintf(stderr, "Failed to open device\n");
+		ret = 1;
+		goto out;
+	}
+
+	/* Initialize buffers */
+	src = malloc(BUF_SIZE * sizeof(char));
+	dst = malloc(BUF_SIZE * sizeof(char));
+	prog = malloc(BUF_SIZE * sizeof(char));
+
+	if (!src || !dst || !prog) {
+		fprintf(stderr, "Failed to allocate buffers\n");
+		ret = 1;
+		goto out_close;
+	}
+
+	memset(src, 0xFF, BUF_SIZE);
+	memset(dst, 0x00, BUF_SIZE);
+	memset(prog, 0x55, BUF_SIZE); /* Not really an eBPF program... */
+
+	/* Send the eBPF program */
+	argp.prog = (uint64_t) prog;
+	ret = ioctl(hermes_fd, HERMES_DOWNLOAD_PROG_IOCTL, &argp);
+	if (ret) {
+		perror("Failed to write eBPF program");
+		goto out_free;
+	}
+
+	/* Write some data */
+	iov.iov_base = src;
+	iov.iov_len = BUF_SIZE;
+	ret = pwritev2(hermes_fd, &iov, 1, 0, 0);
+	if (ret < 0) {
+		perror("Failed to write data");
+		ret = 1;
+		goto out_free;
+	}
+
+	/* Read back into dst */
+	iov.iov_base = dst;
+	iov.iov_len = BUF_SIZE;
+	ret = preadv2(hermes_fd, &iov, 1, 0, 0);
+	if (ret < 0) {
+		perror("Failed to read data");
+		ret = 1;
+		goto out_free;
+	}
+
+	ret = 0;
+
+out_free:
+	free(src);
+	free(dst);
+	free(prog);
+out_close:
+	close(hermes_fd);
+out:
+	return ret;
+}

--- a/src/driver/hermes_cdev.c
+++ b/src/driver/hermes_cdev.c
@@ -112,6 +112,12 @@ static ssize_t hermes_read(struct file *filp, char __user *buff, size_t count,
 	long res;
 	loff_t pos;
 
+	if (env->prog_slot < 0) {
+		dev_err(&env->hermes->dev,
+			"Program has not been downloaded to device. Aborting.\n");
+		return -EBADFD;
+	}
+
 	if (env->data_slot < 0)
 		return -ENODATA;
 

--- a/src/driver/hermes_cdev.c
+++ b/src/driver/hermes_cdev.c
@@ -97,61 +97,24 @@ static int hermes_close(struct inode *inode, struct file *filp)
 	return 0;
 }
 
-static ssize_t hermes_read(struct file *filp, char __user *buff, size_t count,
-		loff_t *f_pos)
+static ssize_t hermes_read_write_iter(struct kiocb *iocb, struct iov_iter *to)
 {
-	struct hermes_env *env = filp->private_data;
+	struct hermes_env *env = iocb->ki_filp->private_data;
 	struct hermes_pci_dev *hpdev = env->hermes->hpdev;
 	struct hermes_cfg *cfg = &hpdev->hdev->cfg;
-	struct iov_iter iter;
-	struct iovec iovec = {
-		.iov_base = (void __user *) buff,
-		.iov_len = count,
-	};
 	struct xdma_channel *chnl;
+	loff_t offset = iocb->ki_pos, pos;
+	bool write = (iov_iter_rw(to) == WRITE);
 	long res;
-	loff_t pos;
 
-	if (env->prog_slot < 0) {
-		dev_err(&env->hermes->dev,
-			"Program has not been downloaded to device. Aborting.\n");
-		return -EBADFD;
-	}
+	if (iocb->ki_flags & (IOCB_DSYNC | IOCB_SYNC | IOCB_APPEND |
+				IOCB_NOWAIT))
+		return -EOPNOTSUPP;
 
-	if (env->data_slot < 0)
-		return -ENODATA;
-
-	if (count + *f_pos > cfg->ehdssze) {
-		count = cfg->ehdssze - *f_pos;
-		if ((int) count < 0)
-			count = 0;
-	}
-
-	chnl = xdma_get_c2h(hpdev);
-
-	pos = cfg->ehdsoff + *f_pos + env->data_slot * cfg->ehdssze;
-
-	iov_iter_init(&iter, READ, &iovec, 1, count);
-	iov_iter_truncate(&iter, cfg->ehdssze - *f_pos);
-	res = xdma_channel_read_write(chnl, &iter, pos);
-
-	return res;
-}
-
-static ssize_t hermes_write(struct file *filp, const char __user *buff,
-		size_t count, loff_t *f_pos)
-{
-	struct hermes_env *env = filp->private_data;
-	struct hermes_pci_dev *hpdev = env->hermes->hpdev;
-	struct hermes_cfg *cfg = &hpdev->hdev->cfg;
-	struct iov_iter iter;
-	struct iovec iovec = {
-		.iov_base = (void __user *) buff,
-		.iov_len = count,
-	};
-	struct xdma_channel *chnl;
-	long res;
-	loff_t pos;
+	if (offset == -1)
+		return -EOPNOTSUPP;
+	else if (offset < 0)
+		return -EINVAL;
 
 	if (env->prog_slot < 0) {
 		dev_err(&env->hermes->dev,
@@ -160,17 +123,23 @@ static ssize_t hermes_write(struct file *filp, const char __user *buff,
 	}
 
 	if (env->data_slot < 0) {
-		env->data_slot = hermes_request_slot_data(hpdev->hdev);
-		if (env->data_slot < 0)
-			return env->data_slot;
+		if (write) {
+			env->data_slot = hermes_request_slot_data(hpdev->hdev);
+			if (env->data_slot < 0)
+				return env->data_slot;
+		} else {
+			return -ENODATA;
+		}
 	}
 
-	chnl = xdma_get_h2c(hpdev);
+	if (write)
+		chnl = xdma_get_h2c(hpdev);
+	else
+		chnl = xdma_get_c2h(hpdev);
 
-	pos = cfg->ehdsoff + *f_pos + env->data_slot * cfg->ehdssze;
-	iov_iter_init(&iter, WRITE, &iovec, 1, count);
-	iov_iter_truncate(&iter, cfg->ehdssze - *f_pos);
-	res = xdma_channel_read_write(chnl, &iter, pos);
+	pos = cfg->ehdsoff + offset + env->data_slot * cfg->ehdssze;
+	iov_iter_truncate(to, cfg->ehdssze - offset);
+	res = xdma_channel_read_write(chnl, to, pos);
 
 	return res;
 }
@@ -238,8 +207,8 @@ static const struct file_operations hermes_fops = {
 	.open = hermes_open,
 	.release = hermes_close,
 	.unlocked_ioctl = hermes_ioctl,
-	.read = hermes_read,
-	.write = hermes_write,
+	.read_iter = hermes_read_write_iter,
+	.write_iter = hermes_read_write_iter,
 };
 
 static struct hermes_dev *to_hermes(struct device *dev)

--- a/src/driver/hermes_cdev.c
+++ b/src/driver/hermes_cdev.c
@@ -153,13 +153,6 @@ static ssize_t hermes_write(struct file *filp, const char __user *buff,
 		return -EBADFD;
 	}
 
-	if (count + *f_pos > cfg->ehdssze) {
-		dev_err(&env->hermes->dev,
-			"Tried to write beyond data slot size. Count: 0x%lx Offset: 0x%llx Slot size:0x%x\n",
-			count, *f_pos, cfg->ehdssze);
-		return -EINVAL;
-	}
-
 	if (env->data_slot < 0) {
 		env->data_slot = hermes_request_slot_data(hpdev->hdev);
 		if (env->data_slot < 0)

--- a/src/driver/hermes_mod.h
+++ b/src/driver/hermes_mod.h
@@ -104,14 +104,6 @@ struct hermes_pci_dev {
 	struct xdma_channel xdma_h2c_chnl[XDMA_CHANNEL_NUM_MAX];
 };
 
-struct xdma_io_cb {
-	void __user *buf;
-	size_t len;
-	unsigned int pages_nr;
-	struct sg_table sgt;
-	struct page **pages;
-};
-
 int hermes_cdev_init(void);
 void hermes_cdev_cleanup(void);
 

--- a/src/driver/libxdma.c
+++ b/src/driver/libxdma.c
@@ -2434,7 +2434,7 @@ ssize_t xdma_xfer_submit(void *dev_hndl, int channel, bool write, u64 ep_addr,
 	}
 
 	if (!dma_mapped) {
-		nents = pci_map_sg(xdev->pdev, sg, sgt->orig_nents, dir);
+		nents = pci_map_sg(xdev->pdev, sg, sgt->nents, dir);
 		if (!nents) {
 			pr_info("map sgl failed, sgt 0x%p.\n", sgt);
 			return -EIO;
@@ -2551,7 +2551,7 @@ ssize_t xdma_xfer_submit(void *dev_hndl, int channel, bool write, u64 ep_addr,
 
 unmap_sgl:
 	if (!dma_mapped && sgt->nents) {
-		pci_unmap_sg(xdev->pdev, sgt->sgl, sgt->orig_nents, dir);
+		pci_unmap_sg(xdev->pdev, sgt->sgl, sgt->nents, dir);
 		sgt->nents = 0;
 	}
 

--- a/src/driver/xdma_sgdma.h
+++ b/src/driver/xdma_sgdma.h
@@ -65,7 +65,7 @@ struct xdma_performance_ioctl {
 
 int hpdev_init_channels(struct hermes_pci_dev *hpdev);
 ssize_t xdma_channel_read_write(struct xdma_channel *chnl,
-		const char __user *buf, size_t count, loff_t *pos, bool write);
+		struct iov_iter *iter, loff_t pos);
 
 static inline struct xdma_channel *xdma_get_c2h(struct hermes_pci_dev *hpdev)
 {

--- a/tests/unit_test
+++ b/tests/unit_test
@@ -111,7 +111,7 @@ class DriverTests(unittest.TestCase):
             os.write(self.hermes, self.payloadSmall)
 
     def testReadBeforeProg(self):
-        with self.assertRaisesRegex(OSError, "No data available"):
+        with self.assertRaisesRegex(OSError, "File descriptor in bad state"):
             os.read(self.hermes, 64)
 
     def testReadBeforeWrite(self):

--- a/tests/unit_test
+++ b/tests/unit_test
@@ -99,7 +99,7 @@ class DriverTests(unittest.TestCase):
 
     def testWriteTooLarge(self):
         payload = b'x' * self.ehdssze * 2
-        with self.assertRaisesRegex(OSError, "Invalid argument"):
+        with self.assertRaisesRegex(AssertionError, "1048576 != 2097152"):
             self._testWriteRead(payload)
 
     def testReadTooLarge(self):
@@ -120,7 +120,7 @@ class DriverTests(unittest.TestCase):
             os.read(self.hermes, 64)
 
     def testWriteLargeOffset(self):
-        with self.assertRaisesRegex(OSError, "Invalid argument"):
+        with self.assertRaisesRegex(AssertionError, "0 != 256"):
             self._testWriteRead(self.payloadSmall, woff=self.ehdssze)
 
     def testReadLargeOffset(self):

--- a/tests/unit_test
+++ b/tests/unit_test
@@ -43,14 +43,21 @@ class DriverTests(unittest.TestCase):
             ret = fcntl.ioctl(self.hermes, cmd, progArgp)
         self.assertEqual(ret, 0)
 
+    def _testWriteReadv(self, payloads, rbuffs, rsize=None, woff=0, roff=0, wflags=0, rflags=0):
+        wsize = sum([len(p) for p in payloads])
+        if not rsize:
+            rsize = sum([len(b) for b in rbuffs])
+        self._sendProgram()
+        ret = os.pwritev(self.hermes, payloads, woff, wflags)
+        self.assertEqual(ret, wsize)
+        ret = os.preadv(self.hermes, rbuffs, roff, rflags)
+        self.assertEqual(ret, rsize)
+
     def _testWriteRead(self, payload, woff=0, roff=0, rsize=None):
         if not rsize:
             rsize = len(payload)
-        self._sendProgram()
-        ret = os.pwrite(self.hermes, payload, woff)
-        self.assertEqual(ret, len(payload))
-        data = os.pread(self.hermes, rsize, roff)
-        self.assertEqual(len(data), rsize)
+        rbuffs = [bytearray(rsize)]
+        self._testWriteReadv([payload], rbuffs, rsize, woff, roff)
 
     def testSendProgram(self):
         self._sendProgram()
@@ -126,6 +133,37 @@ class DriverTests(unittest.TestCase):
     def testReadLargeOffset(self):
         with self.assertRaisesRegex(AssertionError, "0 != 256"):
             self._testWriteRead(self.payloadSmall, roff=self.ehdssze)
+
+    def testWriteReadv(self):
+        payloads = [self.payloadSmall, self.payloadMedium]
+        rbuffs = [bytearray(i) for i in [len(p) for p in payloads]]
+        self._testWriteReadv(payloads, rbuffs)
+
+    def testWriteReadvOneWriteBuffer(self):
+        payloads = [self.payloadSmall]
+        wlen = len(payloads[0])
+        rbuffs = [bytearray(int(wlen/4)) for i in range(4)]
+        self._testWriteReadv(payloads, rbuffs)
+
+    def testWriteReadvOneReadBuffer(self):
+        payloads = [self.payloadSmall, self.payloadMedium]
+        wlen = sum([len(p) for p in payloads])
+        rbuffs = [bytearray(wlen)]
+        self._testWriteReadv(payloads, rbuffs)
+
+    def testWritevFlagNotSupported(self):
+        payloads = [self.payloadSmall]
+        rbuffs = [bytearray(len(payloads[0]))]
+        with self.assertRaisesRegex(OSError, "Operation not supported"):
+            self._testWriteReadv(payloads, rbuffs, wflags=os.RWF_DSYNC)
+        with self.assertRaisesRegex(OSError, "Operation not supported"):
+            self._testWriteReadv(payloads, rbuffs, wflags=os.RWF_SYNC)
+
+    def testReadvFlagNotSupported(self):
+        payloads = [self.payloadSmall]
+        rbuffs = [bytearray(len(payloads[0]))]
+        with self.assertRaisesRegex(OSError, "Operation not supported"):
+            self._testWriteReadv(payloads, rbuffs, rflags=os.RWF_NOWAIT)
 
 if __name__ == '__main__':
     unittest.TestProgram(buffer=True, catchbreak=True)


### PR DESCRIPTION
As discussed on #19, this adds read_iter and write_iter, which support the use of the RWF_ flags, which we plan to use to trigger program execution. Currently, though, no such flags are supported and will be added on a future PR once the qemu device gets the eBPF engines (https://github.com/Eideticom/eid-hermes-qemu/issues/8).