### PR TITLE
Add support for executing programs

### DIFF
--- a/examples/iovec.c
+++ b/examples/iovec.c
@@ -79,12 +79,12 @@ int main()
 		goto out_free;
 	}
 
-	/* Write some data */
+	/* Write some data and start the program (via the RWF_SYNC flag) */
 	iov.iov_base = src;
 	iov.iov_len = BUF_SIZE;
-	ret = pwritev2(hermes_fd, &iov, 1, 0, 0);
+	ret = pwritev2(hermes_fd, &iov, 1, 0, RWF_SYNC);
 	if (ret < 0) {
-		perror("Failed to write data");
+		perror("Failed to write data/execute program");
 		ret = 1;
 		goto out_free;
 	}

--- a/examples/iovec.c
+++ b/examples/iovec.c
@@ -36,7 +36,7 @@ int main()
 	int hermes_fd;
 	int ret;
 	struct hermes_download_prog_ioctl_argp argp = {
-		.len = BUF_SIZE,
+		.len = 16,
 	};
 	struct iovec iov;
 
@@ -51,7 +51,7 @@ int main()
 	/* Initialize buffers */
 	src = malloc(BUF_SIZE * sizeof(char));
 	dst = malloc(BUF_SIZE * sizeof(char));
-	prog = malloc(BUF_SIZE * sizeof(char));
+	prog = malloc(16 * sizeof(char));
 
 	if (!src || !dst || !prog) {
 		fprintf(stderr, "Failed to allocate buffers\n");
@@ -61,7 +61,15 @@ int main()
 
 	memset(src, 0xFF, BUF_SIZE);
 	memset(dst, 0x00, BUF_SIZE);
-	memset(prog, 0x55, BUF_SIZE); /* Not really an eBPF program... */
+
+	/*
+	 * Create an eBPF program with two instructions:
+	 *     r0 = 0 (b7 00 00 00 00 00 00 00)
+	 *     ret    (95 00 00 00 00 00 00 00)
+	 */
+	memset(prog, 0, 16);
+	prog[0] = 0xb7;
+	prog[8] = 0x95;
 
 	/* Send the eBPF program */
 	argp.prog = (uint64_t) prog;

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -82,6 +82,14 @@ int main()
 		goto out_free;
 	}
 
+	/* Trigger program execution */
+	ret = fsync(hermes_fd);
+	if (ret < 0) {
+		perror("Failed to execute program");
+		ret = 1;
+		goto out_free;
+	}
+
 	/* Read back into dst */
 	ret = read(hermes_fd, dst, BUF_SIZE);
 	if (ret < 0) {

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -32,7 +32,7 @@ int main()
 	int hermes_fd;
 	int ret;
 	struct hermes_download_prog_ioctl_argp argp = {
-		.len = BUF_SIZE,
+		.len = 16,
 	};
 
 	/* Open device */
@@ -46,7 +46,7 @@ int main()
 	/* Initialize buffers */
 	src = malloc(BUF_SIZE * sizeof(char));
 	dst = malloc(BUF_SIZE * sizeof(char));
-	prog = malloc(BUF_SIZE * sizeof(char));
+	prog = malloc(16 * sizeof(char));
 
 	if (!src || !dst || !prog) {
 		fprintf(stderr, "Failed to allocate buffers\n");
@@ -56,7 +56,15 @@ int main()
 
 	memset(src, 0xFF, BUF_SIZE);
 	memset(dst, 0x00, BUF_SIZE);
-	memset(prog, 0x55, BUF_SIZE); /* Not really an eBPF program... */
+
+	/*
+	 * Create an eBPF program with two instructions:
+	 *     r0 = 0 (b7 00 00 00 00 00 00 00)
+	 *     ret    (95 00 00 00 00 00 00 00)
+	 */
+	memset(prog, 0, 16);
+	prog[0] = 0xb7;
+	prog[8] = 0x95;
 
 	/* Send the eBPF program */
 	argp.prog = (uint64_t) prog;

--- a/specs/eid-hermes-driver-interface.md
+++ b/specs/eid-hermes-driver-interface.md
@@ -13,7 +13,7 @@ device, which can be used by an userspace program to interact with the device.
 ## Syscalls
 
 The `/dev/hermesX` device file supports the `open`, `close`, `ioctl`, `write`
-and `read` syscalls.
+`read` and `fsync` syscalls.
 
 Programs can be sent to the device using an `ioctl`: the request number and the
 pointer structure are defined [here][3]. A program slot is automatically
@@ -22,6 +22,14 @@ allocated upon the first `ioctl` and reused for subsequent `ioctl`s.
 Data can be written/read from the device using the `write`/`read` syscalls. A
 data slot is automatically allocated upon the first `write` and reused for
 subsequent `write`s/`read`s.
+
+Programs can be executed by either passing the `RWF_SYNC` flag to a `pwritev2`
+syscall (in which case the driver will first write the program then immediately
+execute the program) or by using the `fsync` syscall. These syscalls expect the
+program to exit with 0 and will fail with errno `ENOEXEC` if that does not
+happen. Programmers that need to know the eBPF return code must write their
+eBPF programs so that the return code is written into a known offset of the
+data slot, which can then be `read`.
 
 ## Example
 

--- a/src/driver/hermes_cdev.c
+++ b/src/driver/hermes_cdev.c
@@ -123,7 +123,7 @@ static int hermes_fsync(struct file *filp, loff_t start, loff_t end, int datasyn
 			.prog_len = env->prog_len,
 		},
 	};
-	int eng = 0, res;
+	int eng, res;
 	int64_t ebpf_ret;
 
 	if (env->prog_slot < 0) {
@@ -137,6 +137,10 @@ static int hermes_fsync(struct file *filp, loff_t start, loff_t end, int datasyn
 			"No data has been transferred to device. Aborting.\n");
 		return -EBADFD;
 	}
+
+	eng = hermes_get_ebpf_eng(hermes);
+	if (eng < 0)
+		return eng;
 
 	pr_debug("opcode: 0x%x cid: 0x%x prog_slot: 0x%x data_slot: 0x%x\n",
 			cmd.req.opcode, cmd.req.cid, cmd.req.prog_slot,
@@ -200,6 +204,7 @@ static int hermes_fsync(struct file *filp, loff_t start, loff_t end, int datasyn
 
 out:
 	env->cid++;
+	hermes_release_ebpf_eng(hermes, eng);
 	return res;
 }
 

--- a/src/driver/hermes_cdev.c
+++ b/src/driver/hermes_cdev.c
@@ -44,6 +44,7 @@ struct hermes_env {
 	struct hermes_dev *hermes;
 	int32_t prog_slot;
 	int32_t data_slot;
+	int32_t prog_len;
 };
 
 static inline void hermes_release_slot_prog(struct hermes_env *env)
@@ -174,6 +175,7 @@ static long hermes_download_program(struct hermes_env *env,
 			argp->len, cfg->ehpssze);
 		return -EINVAL;
 	}
+	env->prog_len = argp->len;
 
 	if (env->prog_slot < 0) {
 		env->prog_slot = hermes_request_slot_prog(hpdev->hdev);

--- a/src/driver/hermes_mod.c
+++ b/src/driver/hermes_mod.c
@@ -70,9 +70,10 @@ static void disable_msi_msix(struct pci_dev *pdev)
 	pci_disable_msix(pdev);
 }
 
-static int enable_msi_msix(struct xdma_dev *xdev)
+static int enable_msi_msix(struct hermes_pci_dev *hpdev)
 {
-	struct pci_dev *pdev = xdev->pdev;
+	struct xdma_dev *xdev = hpdev->xdev;
+	struct pci_dev *pdev = hpdev->pdev;
 	int rv, req_nvec;
 
 	if (unlikely(!xdev || !pdev)) {
@@ -190,7 +191,7 @@ static int probe_one(struct pci_dev *pdev, const struct pci_device_id *id)
 	if (rv)
 		goto err_out;
 
-	rv = enable_msi_msix(xdev);
+	rv = enable_msi_msix(hpdev);
 	if (rv < 0)
 		goto err_enable_msix;
 

--- a/src/driver/hermes_mod.c
+++ b/src/driver/hermes_mod.c
@@ -155,6 +155,8 @@ static void hpdev_free(struct hermes_pci_dev *hpdev)
 
 	ida_destroy(&hpdev->c2h_ida_wq.ida);
 	ida_destroy(&hpdev->h2c_ida_wq.ida);
+	ida_destroy(&hpdev->hdev->ebpf_engines_ida_wq.ida);
+
 	hpdev->xdev = NULL;
 	pr_info("hpdev 0x%p, xdev 0x%p xdma_device_close.\n", hpdev, xdev);
 	xdma_device_close(hpdev->pdev, xdev);
@@ -258,6 +260,7 @@ static int probe_one(struct pci_dev *pdev, const struct pci_device_id *id)
 
 	init_ida_wq(&hpdev->c2h_ida_wq, hpdev->c2h_channel_max - 1);
 	init_ida_wq(&hpdev->h2c_ida_wq, hpdev->h2c_channel_max - 1);
+	init_ida_wq(&hpdev->hdev->ebpf_engines_ida_wq, hpdev->hdev->cfg.eheng);
 
 	dev_set_drvdata(&pdev->dev, hpdev);
 
@@ -418,6 +421,16 @@ void xdma_release_h2c(struct xdma_channel *chnl)
 
 	hpdev = container_of(chnl, struct hermes_pci_dev, xdma_h2c_chnl[id]);
 	ida_wq_release(&hpdev->h2c_ida_wq, id);
+}
+
+int hermes_get_ebpf_eng(struct hermes_dev *hdev)
+{
+	return ida_wq_get(&hdev->ebpf_engines_ida_wq);
+}
+
+void hermes_release_ebpf_eng(struct hermes_dev *hdev, int engine)
+{
+	ida_wq_release(&hdev->ebpf_engines_ida_wq, engine);
 }
 
 static struct pci_driver pci_driver = {

--- a/src/driver/hermes_mod.c
+++ b/src/driver/hermes_mod.c
@@ -78,6 +78,7 @@ static irqreturn_t ebpf_irq(int irq, void *ptr)
 {
 	struct ebpf_irq *arg = ptr;
 	pr_debug("(irq=%d) eBPF interrupt handler\n", irq);
+	wake_up_interruptible(&arg->wq);
 
 	return IRQ_HANDLED;
 }
@@ -97,6 +98,7 @@ static int ebpf_irq_setup(struct hermes_dev *hdev, int first)
 			return rc;
 		}
 		pr_info("eBPF engine %d, irq#%d.\n", i, vector);
+		init_waitqueue_head(&hdev->irq[i].wq);
 		hdev->irq[i].irq_line = vector;
 	}
 

--- a/src/driver/hermes_mod.c
+++ b/src/driver/hermes_mod.c
@@ -55,14 +55,67 @@ static const struct pci_device_id pci_ids[] = {
 };
 MODULE_DEVICE_TABLE(pci, pci_ids);
 
+static void ebpf_msix_teardown(struct hermes_dev *hdev)
+{
+	int i;
+
+	for (i = 0; i < hdev->cfg.eheng; i++) {
+		if (!hdev->irq[i].irq_line)
+			break;
+		pr_debug("Release IRQ#%d for eBPF engine %d\n",
+			hdev->irq[i].irq_line, i);
+		free_irq(hdev->irq[i].irq_line, &hdev->irq[i]);
+	}
+}
+
 static void irq_teardown(struct hermes_pci_dev *hpdev)
 {
 	xdma_irq_teardown(hpdev->xdev);
+	ebpf_msix_teardown(hpdev->hdev);
+}
+
+static irqreturn_t ebpf_irq(int irq, void *ptr)
+{
+	struct ebpf_irq *arg = ptr;
+	pr_debug("(irq=%d) eBPF interrupt handler\n", irq);
+
+	return IRQ_HANDLED;
+}
+
+static int ebpf_irq_setup(struct hermes_dev *hdev, int first)
+{
+	unsigned int vector;
+	int i, rc;
+
+	for (i = 0; i < hdev->cfg.eheng; i++) {
+		vector = pci_irq_vector(hdev->pdev, first + i);
+		rc = request_irq(vector, ebpf_irq, 0, DRV_MODULE_NAME,
+				&hdev->irq[i]);
+		if (rc) {
+			pr_err("request irq#%d failed %d, eBPF engine %d.\n",
+				vector, rc, i);
+			return rc;
+		}
+		pr_info("eBPF engine %d, irq#%d.\n", i, vector);
+		hdev->irq[i].irq_line = vector;
+	}
+
+	return 0;
 }
 
 static int irq_setup(struct hermes_pci_dev *hpdev)
 {
-	return xdma_irq_setup(hpdev->xdev);
+	struct xdma_dev *xdev = hpdev->xdev;
+	int rc;
+
+	rc = xdma_irq_setup(xdev);
+	if (rc)
+		goto out;
+
+	rc = ebpf_irq_setup(hpdev->hdev, xdev->h2c_channel_max +
+			xdev->c2h_channel_max);
+out:
+	return rc;
 }
 
 static void disable_msi_msix(struct pci_dev *pdev)
@@ -72,6 +125,7 @@ static void disable_msi_msix(struct pci_dev *pdev)
 
 static int enable_msi_msix(struct hermes_pci_dev *hpdev)
 {
+	struct hermes_dev *hdev = hpdev->hdev;
 	struct xdma_dev *xdev = hpdev->xdev;
 	struct pci_dev *pdev = hpdev->pdev;
 	int rv, req_nvec;
@@ -81,7 +135,8 @@ static int enable_msi_msix(struct hermes_pci_dev *hpdev)
 		return -EINVAL;
 	}
 
-	req_nvec = xdev->c2h_channel_max + xdev->h2c_channel_max;
+	req_nvec = xdev->c2h_channel_max + xdev->h2c_channel_max +
+		hdev->cfg.eheng;
 
 	pr_debug("Enabling MSI-X\n");
 	rv = pci_alloc_irq_vectors(pdev, req_nvec, req_nvec,

--- a/src/driver/hermes_mod.h
+++ b/src/driver/hermes_mod.h
@@ -77,6 +77,10 @@ struct __attribute__((__packed__)) hermes_cfg {
 	uint32_t ehdssze;
 };
 
+struct ebpf_irq {
+	int irq_line;
+};
+
 struct hermes_dev {
 	struct device dev;
 	struct pci_dev *pdev;
@@ -87,6 +91,8 @@ struct hermes_dev {
 	struct hermes_cfg cfg;
 	struct ida prog_slots;
 	struct ida data_slots;
+
+	struct ebpf_irq *irq;
 };
 
 struct ida_wq {

--- a/src/driver/hermes_mod.h
+++ b/src/driver/hermes_mod.h
@@ -125,6 +125,12 @@ struct ebpf_irq {
 	int irq_line;
 };
 
+struct ida_wq {
+	struct ida ida;
+	unsigned int max;
+	wait_queue_head_t wq;
+};
+
 struct hermes_dev {
 	struct device dev;
 	struct pci_dev *pdev;
@@ -140,12 +146,6 @@ struct hermes_dev {
 	struct hermes_cmd_ctrl __iomem *cmds_ctrl;
 
 	struct ebpf_irq *irq;
-};
-
-struct ida_wq {
-	struct ida ida;
-	unsigned int max;
-	wait_queue_head_t wq;
 };
 
 /* XDMA PCIe device specific book-keeping */

--- a/src/driver/hermes_mod.h
+++ b/src/driver/hermes_mod.h
@@ -142,6 +142,8 @@ struct hermes_dev {
 	struct ida prog_slots;
 	struct ida data_slots;
 
+	struct ida_wq ebpf_engines_ida_wq;
+
 	struct hermes_cmd __iomem *cmds;
 	struct hermes_cmd_ctrl __iomem *cmds_ctrl;
 
@@ -168,6 +170,8 @@ struct xdma_channel *xdma_get_c2h(struct hermes_pci_dev *hpdev);
 struct xdma_channel *xdma_get_h2c(struct hermes_pci_dev *hpdev);
 void xdma_release_c2h(struct xdma_channel *chnl);
 void xdma_release_h2c(struct xdma_channel *chnl);
+int hermes_get_ebpf_eng(struct hermes_dev *hdev);
+void hermes_release_ebpf_eng(struct hermes_dev *hdev, int engine);
 
 int hermes_cdev_init(void);
 void hermes_cdev_cleanup(void);

--- a/src/driver/hermes_mod.h
+++ b/src/driver/hermes_mod.h
@@ -59,6 +59,16 @@
 extern unsigned int desc_blen_max;
 extern unsigned int sgdma_timeout;
 
+enum hermes_status {
+	HERMES_SUCCESS       = 0x00,
+	HERMES_NO_SPACE      = 0x01,
+	HERMES_INV_PROG_SLOT = 0x02,
+	HERMES_INV_DATA_SLOT = 0x03,
+	HERMES_INV_ADDR      = 0x04,
+	HERMES_EBPF_ERROR    = 0x05,
+	HERMES_INV_OPCODE    = 0x06,
+};
+
 struct xdma_channel {
 	struct xdma_dev *xdev;
 	struct xdma_engine *engine;	/* engine instance, if needed */
@@ -77,7 +87,41 @@ struct __attribute__((__packed__)) hermes_cfg {
 	uint32_t ehdssze;
 };
 
+struct __attribute__((__packed__)) hermes_cmd_req {
+	uint8_t opcode;
+	uint8_t rsv0;
+	uint16_t cid;
+	uint32_t rsv1;
+
+	uint8_t prog_slot;
+	uint8_t data_slot;
+	uint16_t rsv2;
+	uint32_t prog_len;
+
+	uint8_t rsv3[16];
+};
+
+struct __attribute__((__packed__)) hermes_cmd_res {
+	uint16_t cid;
+	uint8_t status;
+	uint8_t rsv[5];
+
+	uint64_t ebpf_ret;
+};
+
+struct __attribute__((__packed__)) hermes_cmd {
+	struct hermes_cmd_req req;
+	struct hermes_cmd_res res;
+};
+
+struct __attribute__((__packed__)) hermes_cmd_ctrl {
+	uint8_t ehcmdexec;
+	uint8_t ehcmddone;
+	uint8_t rsv[6];
+};
+
 struct ebpf_irq {
+	wait_queue_head_t wq;
 	int irq_line;
 };
 
@@ -91,6 +135,9 @@ struct hermes_dev {
 	struct hermes_cfg cfg;
 	struct ida prog_slots;
 	struct ida data_slots;
+
+	struct hermes_cmd __iomem *cmds;
+	struct hermes_cmd_ctrl __iomem *cmds_ctrl;
 
 	struct ebpf_irq *irq;
 };

--- a/tests/unit_test
+++ b/tests/unit_test
@@ -17,7 +17,8 @@ class DriverTests(unittest.TestCase):
     ehpslot = 16
     ehpssze = 1024 * 1024
     ehdssze = 1024 * 1024
-    prog = b'x' * 4096
+    prog = bytes.fromhex('b7 00 00 00 00 00 00 00'  # r0 = 0
+                       + '95 00 00 00 00 00 00 00') # ret
     payloadSmall  = b'z' * 256
     payloadMedium = b'z' * 4096
     payloadLarge  = b'z' * ehdssze

--- a/tests/unit_test
+++ b/tests/unit_test
@@ -44,21 +44,23 @@ class DriverTests(unittest.TestCase):
             ret = fcntl.ioctl(self.hermes, cmd, progArgp)
         self.assertEqual(ret, 0)
 
-    def _testWriteReadv(self, payloads, rbuffs, rsize=None, woff=0, roff=0, wflags=0, rflags=0):
+    def _testWriteReadv(self, payloads, rbuffs, prog=None, rsize=None, woff=0, roff=0, wflags=0, rflags=0):
         wsize = sum([len(p) for p in payloads])
+        if not prog:
+            prog = self.prog
         if not rsize:
             rsize = sum([len(b) for b in rbuffs])
-        self._sendProgram()
+        self._sendProgram(prog)
         ret = os.pwritev(self.hermes, payloads, woff, wflags)
         self.assertEqual(ret, wsize)
         ret = os.preadv(self.hermes, rbuffs, roff, rflags)
         self.assertEqual(ret, rsize)
 
-    def _testWriteRead(self, payload, woff=0, roff=0, rsize=None):
+    def _testWriteRead(self, payload, prog=None, woff=0, roff=0, rsize=None):
         if not rsize:
             rsize = len(payload)
         rbuffs = [bytearray(rsize)]
-        self._testWriteReadv([payload], rbuffs, rsize, woff, roff)
+        self._testWriteReadv([payload], rbuffs, prog, rsize, woff, roff)
 
     def testSendProgram(self):
         self._sendProgram()
@@ -152,19 +154,35 @@ class DriverTests(unittest.TestCase):
         rbuffs = [bytearray(wlen)]
         self._testWriteReadv(payloads, rbuffs)
 
-    def testWritevFlagNotSupported(self):
-        payloads = [self.payloadSmall]
-        rbuffs = [bytearray(len(payloads[0]))]
-        with self.assertRaisesRegex(OSError, "Operation not supported"):
-            self._testWriteReadv(payloads, rbuffs, wflags=os.RWF_DSYNC)
-        with self.assertRaisesRegex(OSError, "Operation not supported"):
-            self._testWriteReadv(payloads, rbuffs, wflags=os.RWF_SYNC)
-
     def testReadvFlagNotSupported(self):
         payloads = [self.payloadSmall]
         rbuffs = [bytearray(len(payloads[0]))]
         with self.assertRaisesRegex(OSError, "Operation not supported"):
             self._testWriteReadv(payloads, rbuffs, rflags=os.RWF_NOWAIT)
+
+    def testWritevRWF_SYNC(self):
+        payloads = [self.payloadSmall]
+        rbuffs = [bytearray(len(payloads[0]))]
+        self._testWriteReadv(payloads, rbuffs, wflags=os.RWF_SYNC)
+
+    def testFsync(self):
+        self._testWriteRead(self.payloadSmall)
+        os.fsync(self.hermes)
+
+    def testFsyncBeforeProg(self):
+        with self.assertRaisesRegex(OSError, "File descriptor in bad state"):
+            os.fsync(self.hermes)
+
+    def testFsyncBeforeWrite(self):
+        self._sendProgram()
+        with self.assertRaisesRegex(OSError, "File descriptor in bad state"):
+            os.fsync(self.hermes)
+
+    def testInvalidProg(self):
+        prog = bytes.fromhex('ff ff ff ff ff ff ff ff')
+        self._testWriteRead(self.payloadSmall, prog)
+        with self.assertRaisesRegex(OSError, "Exec format error"):
+            os.fsync(self.hermes)
 
 if __name__ == '__main__':
     unittest.TestProgram(buffer=True, catchbreak=True)


### PR DESCRIPTION
This PR adds support for executing eBPF programs on Hermes devices.

This is done either through an fsync() or by passing the RWF_SYNC flag to pwritev2().

Note that this is based on #21 and as such only the last 5 commits are actually part of this PR. I'll rebase once #21 gets in.

Also, I'm marking this as a draft PR because we don't yet have eBPF engines on the QEMU device (https://github.com/Eideticom/eid-hermes-qemu/issues/8), so I can't fully test it. But it seems to be writing/reading the right things at the right offsets. I'll change it to a regular PR once we're satisfied with https://github.com/Eideticom/eid-hermes-qemu/issues/8.