### PR TITLE
specs: add new status and register

### DIFF
--- a/specs/eid-hermes-commands-format.md
+++ b/specs/eid-hermes-commands-format.md
@@ -89,6 +89,7 @@ The following `Status` of Command Responses are defined:
 | 0x03   | Invalid Data Slot    |
 | 0x04   | Invalid Address      |
 | 0x05   | eBPF error           |
+| 0x06   | Invalid opcode       |
 
 **Table 3: Status**
 

--- a/specs/eid-hermes-interface.md
+++ b/specs/eid-hermes-interface.md
@@ -53,9 +53,16 @@ commands.
 | ...                    | ...    | ...          | ...  | ...   | ... |
 | 0x1000 + (EHENG-1)\*48 | 32     | EHCMDREQN-1  | RW   | NA    | Command Request for engine N-1 |
 | 0x1020 + (EHENG-1)\*48 | 16     | EHCMDRESN-1  | RO   | NA    | Command Response for engine N-1 |
-| 0x2000                 | 1      | EHCMDCTRL0   | RW   | NA    | Write 1 to start Command Request 0. Cleared after command finishes |
+| 0x2000                 | 1      | EHCMDCTRL0   | RW   | NA    | Command control for request 0. See EHCMDCTRL table for details |
 | ...                    | ...    | ...          | ...  | ...   | ... |
-| 0x2000 + (EHENG-1)     | 1      | EHCMDCTRLN-1 | RW   | NA    | Write 1 to start Command Request N-1. Cleared after command finishes |
+| 0x2000 + (EHENG-1)     | 1      | EHCMDCTRLN-1 | RW   | NA    | Command control for request N-1. See EHCMDCTRL table for details |
+
+#### EHCMDCTRL
+| Bit | Name      | Mode | Description |
+|-----|-----------|------|-------------|
+|  0  | EHCMDEXEC | RW   | Host writes 1 to start command. Device clears after command finishes |
+|  1  | EHCMDDONE | RO   | Indicates if command has finished. Cleared by device before starting command, set when done |
+| 2-7 | --        | --   | Reserved |
 
 ## BAR2 Layout
 

--- a/specs/eid-hermes-theory-of-operation.md
+++ b/specs/eid-hermes-theory-of-operation.md
@@ -44,8 +44,7 @@ memory. The eBPF program may reference memory via offsets into the
 eBPF program memory. The eBPF program may populate parts of the eBPF
 program memory with both intermediate data *and* output data. Once the
 eBPF program has completed the device will inform the host via an
-interrupt. The host can also choose to poll the relevant BAR0 register
-to check for command completion.
+interrupt and set the `EHCMDDONE` register, which can be checked by the host.
 
 4. Host uses a driver to exercise BAR2 to initate DMAs on the device
 that take the output data from the relevant eBPF data slot and move it


### PR DESCRIPTION
A couple of minor edits to the specs, adding a new command return code (invalid opcode) and a new register that shows when a command has completed.