### PR TITLE
driver: select an idle XDMA channel

### DIFF
--- a/src/driver/hermes_mod.c
+++ b/src/driver/hermes_mod.c
@@ -265,6 +265,16 @@ static const struct pci_error_handlers xdma_err_handler = {
 #endif
 };
 
+struct xdma_channel *xdma_get_c2h(struct hermes_pci_dev *hpdev)
+{
+	return &hpdev->xdma_c2h_chnl[0];
+}
+
+struct xdma_channel *xdma_get_h2c(struct hermes_pci_dev *hpdev)
+{
+	return &hpdev->xdma_h2c_chnl[0];
+}
+
 static struct pci_driver pci_driver = {
 	.name = DRV_MODULE_NAME,
 	.id_table = pci_ids,

--- a/src/driver/hermes_mod.h
+++ b/src/driver/hermes_mod.h
@@ -104,6 +104,9 @@ struct hermes_pci_dev {
 	struct xdma_channel xdma_h2c_chnl[XDMA_CHANNEL_NUM_MAX];
 };
 
+struct xdma_channel *xdma_get_c2h(struct hermes_pci_dev *hpdev);
+struct xdma_channel *xdma_get_h2c(struct hermes_pci_dev *hpdev);
+
 int hermes_cdev_init(void);
 void hermes_cdev_cleanup(void);
 

--- a/src/driver/hermes_mod.h
+++ b/src/driver/hermes_mod.h
@@ -91,6 +91,12 @@ struct hermes_dev {
 	struct ida data_slots;
 };
 
+struct ida_wq {
+	struct ida ida;
+	unsigned int max;
+	wait_queue_head_t wq;
+};
+
 /* XDMA PCIe device specific book-keeping */
 struct hermes_pci_dev {
 	unsigned long magic;		/* structure ID for sanity checks */
@@ -102,10 +108,15 @@ struct hermes_pci_dev {
 
 	struct xdma_channel xdma_c2h_chnl[XDMA_CHANNEL_NUM_MAX];
 	struct xdma_channel xdma_h2c_chnl[XDMA_CHANNEL_NUM_MAX];
+
+	struct ida_wq c2h_ida_wq;
+	struct ida_wq h2c_ida_wq;
 };
 
 struct xdma_channel *xdma_get_c2h(struct hermes_pci_dev *hpdev);
 struct xdma_channel *xdma_get_h2c(struct hermes_pci_dev *hpdev);
+void xdma_release_c2h(struct xdma_channel *chnl);
+void xdma_release_h2c(struct xdma_channel *chnl);
 
 int hermes_cdev_init(void);
 void hermes_cdev_cleanup(void);

--- a/src/driver/xdma_sgdma.h
+++ b/src/driver/xdma_sgdma.h
@@ -67,17 +67,6 @@ int hpdev_init_channels(struct hermes_pci_dev *hpdev);
 ssize_t xdma_channel_read_write(struct xdma_channel *chnl,
 		struct iov_iter *iter, loff_t pos);
 
-static inline struct xdma_channel *xdma_get_c2h(struct hermes_pci_dev *hpdev)
-{
-	return &hpdev->xdma_c2h_chnl[0];
-}
-
-static inline struct xdma_channel *xdma_get_h2c(struct hermes_pci_dev *hpdev)
-{
-	return &hpdev->xdma_h2c_chnl[0];
-}
-
-
 /* IOCTL codes */
 
 #define IOCTL_XDMA_PERF_START   _IOW('q', 1, struct xdma_performance_ioctl *)


### PR DESCRIPTION
Use an IDA to keep track of which XDMA channels are being used. If there
are no idle channels, retry until one is available, or until a time
threshold is met, in which case the syscall will fail with EBUSY.