### PR TITLE
XDMA cleanup part 2

### DIFF
--- a/src/driver/hermes_mod.c
+++ b/src/driver/hermes_mod.c
@@ -370,7 +370,7 @@ static int __init hermes_mod_init(void)
 static void __exit hermes_mod_exit(void)
 {
 	/* unregister this driver from the PCI bus driver */
-	dbg_init("pci_unregister_driver.\n");
+	pr_debug("pci_unregister_driver.\n");
 	pci_unregister_driver(&pci_driver);
 	hermes_cdev_cleanup();
 }

--- a/src/driver/libxdma.c
+++ b/src/driver/libxdma.c
@@ -137,9 +137,77 @@ inline void __write_register(const char *fn, u32 value, void *iomem, unsigned lo
 	iowrite32(value, iomem);
 }
 #define write_register(v, mem, off) __write_register(__func__, v, mem, off)
+static void dump_desc(struct xdma_desc *desc_virt)
+{
+	int j;
+	u32 *p = (u32 *)desc_virt;
+	static char * const field_name[] = {	"magic|extra_adjacent|control",
+						"bytes",
+						"src_addr_lo",
+						"src_addr_hi",
+						"dst_addr_lo",
+						"dst_addr_hi",
+						"next_addr",
+						"next_addr_pad"};
+	char *dummy;
+
+	/* remove warning about unused variable when debug printing is off */
+	dummy = field_name[0];
+
+	for (j = 0; j < 8; j += 1) {
+		pr_info("0x%08lx/0x%02lx: 0x%08x 0x%08x %s\n",
+			 (uintptr_t)p, (uintptr_t)p & 15, (int)*p,
+			 le32_to_cpu(*p), field_name[j]);
+		p++;
+	}
+	pr_info("\n");
+}
+
+static void transfer_dump(struct xdma_transfer *transfer)
+{
+	int i;
+	struct xdma_desc *desc_virt = transfer->desc_virt;
+
+	pr_info("xfer 0x%p, state 0x%x, f 0x%x, dir %d, len %u, last %d.\n",
+		transfer, transfer->state, transfer->flags, transfer->dir,
+		transfer->len, transfer->last_in_request);
+
+	pr_info("transfer 0x%p, desc %d, bus 0x%llx, adj %d.\n",
+		transfer, transfer->desc_num, (u64)transfer->desc_bus,
+		transfer->desc_adjacent);
+	for (i = 0; i < transfer->desc_num; i += 1)
+		dump_desc(desc_virt + i);
+}
+
+static void sgt_dump(struct sg_table *sgt)
+{
+	int i;
+	struct scatterlist *sg = sgt->sgl;
+
+	pr_info("sgt 0x%p, sgl 0x%p, nents %u/%u.\n",
+		sgt, sgt->sgl, sgt->nents, sgt->nents);
+
+	for (i = 0; i < sgt->nents; i++, sg = sg_next(sg))
+		pr_info("%d, 0x%p, pg 0x%p,%u+%u, dma 0x%llx,%u.\n",
+			i, sg, sg_page(sg), sg->offset, sg->length,
+			sg_dma_address(sg), sg_dma_len(sg));
+}
+
+static void xdma_request_cb_dump(struct xdma_request_cb *req)
+{
+	int i;
+
+	pr_info("request 0x%p, total %u, ep 0x%llx, sw_desc %u, sgt 0x%p.\n",
+		req, req->total_len, req->ep_addr, req->sw_desc_cnt, req->sgt);
+	sgt_dump(req->sgt);
+	for (i = 0; i < req->sw_desc_cnt; i++)
+		pr_info("%d/%u, 0x%llx, %u.\n",
+			i, req->sw_desc_cnt, req->sdesc[i].addr,
+			req->sdesc[i].len);
+}
 #else
 #define write_register(v, mem, off) iowrite32(v, mem)
-#endif
+#endif /* __LIBXDMA_DEBUG__ */
 
 inline u32 read_register(void *iomem)
 {
@@ -1323,50 +1391,6 @@ static int irq_setup(struct xdma_dev *xdev, struct pci_dev *pdev)
 	return 0;
 }
 
-#ifdef __LIBXDMA_DEBUG__
-static void dump_desc(struct xdma_desc *desc_virt)
-{
-	int j;
-	u32 *p = (u32 *)desc_virt;
-	static char * const field_name[] = {	"magic|extra_adjacent|control",
-						"bytes",
-						"src_addr_lo",
-						"src_addr_hi",
-						"dst_addr_lo",
-						"dst_addr_hi",
-						"next_addr",
-						"next_addr_pad"};
-	char *dummy;
-
-	/* remove warning about unused variable when debug printing is off */
-	dummy = field_name[0];
-
-	for (j = 0; j < 8; j += 1) {
-		pr_info("0x%08lx/0x%02lx: 0x%08x 0x%08x %s\n",
-			 (uintptr_t)p, (uintptr_t)p & 15, (int)*p,
-			 le32_to_cpu(*p), field_name[j]);
-		p++;
-	}
-	pr_info("\n");
-}
-
-static void transfer_dump(struct xdma_transfer *transfer)
-{
-	int i;
-	struct xdma_desc *desc_virt = transfer->desc_virt;
-
-	pr_info("xfer 0x%p, state 0x%x, f 0x%x, dir %d, len %u, last %d.\n",
-		transfer, transfer->state, transfer->flags, transfer->dir,
-		transfer->len, transfer->last_in_request);
-
-	pr_info("transfer 0x%p, desc %d, bus 0x%llx, adj %d.\n",
-		transfer, transfer->desc_num, (u64)transfer->desc_bus,
-		transfer->desc_adjacent);
-	for (i = 0; i < transfer->desc_num; i += 1)
-		dump_desc(desc_virt + i);
-}
-#endif /* __LIBXDMA_DEBUG__ */
-
 /* transfer_desc_init() - Chains the descriptors as a singly-linked list
  *
  * Each descriptor's next * pointer specifies the bus address
@@ -1885,35 +1909,6 @@ static int transfer_init(struct xdma_engine *engine, struct xdma_request_cb *req
 
 	return 0;
 }
-
-#ifdef __LIBXDMA_DEBUG__
-static void sgt_dump(struct sg_table *sgt)
-{
-	int i;
-	struct scatterlist *sg = sgt->sgl;
-
-	pr_info("sgt 0x%p, sgl 0x%p, nents %u/%u.\n",
-		sgt, sgt->sgl, sgt->nents, sgt->nents);
-
-	for (i = 0; i < sgt->nents; i++, sg = sg_next(sg))
-		pr_info("%d, 0x%p, pg 0x%p,%u+%u, dma 0x%llx,%u.\n",
-			i, sg, sg_page(sg), sg->offset, sg->length,
-			sg_dma_address(sg), sg_dma_len(sg));
-}
-
-static void xdma_request_cb_dump(struct xdma_request_cb *req)
-{
-	int i;
-
-	pr_info("request 0x%p, total %u, ep 0x%llx, sw_desc %u, sgt 0x%p.\n",
-		req, req->total_len, req->ep_addr, req->sw_desc_cnt, req->sgt);
-	sgt_dump(req->sgt);
-	for (i = 0; i < req->sw_desc_cnt; i++)
-		pr_info("%d/%u, 0x%llx, %u.\n",
-			i, req->sw_desc_cnt, req->sdesc[i].addr,
-			req->sdesc[i].len);
-}
-#endif
 
 static void xdma_request_free(struct xdma_request_cb *req)
 {

--- a/src/driver/libxdma.c
+++ b/src/driver/libxdma.c
@@ -206,6 +206,9 @@ static void xdma_request_cb_dump(struct xdma_request_cb *req)
 			req->sdesc[i].len);
 }
 #else
+static void xdma_request_cb_dump(struct xdma_request_cb *req) {}
+static void transfer_dump(struct xdma_transfer *transfer) {}
+static void sgt_dump(struct sg_table *sgt) {}
 #define write_register(v, mem, off) iowrite32(v, mem)
 #endif /* __LIBXDMA_DEBUG__ */
 
@@ -1986,17 +1989,13 @@ static struct xdma_request_cb * xdma_init_request(struct sg_table *sgt,
 
 	if (unlikely(j > max)) {
 		pr_err("too many sdesc %d > %d\n", j, max);
-#ifdef __LIBXDMA_DEBUG__
 		xdma_request_cb_dump(req);
-#endif
 		xdma_request_free(req);
 		return NULL;
 	}
 
 	req->sw_desc_cnt = j;
-#ifdef __LIBXDMA_DEBUG__
 	xdma_request_cb_dump(req);
-#endif
 	return req;
 }
 
@@ -2109,9 +2108,7 @@ ssize_t xdma_xfer_submit(void *dev_hndl, int channel, bool write, u64 ep_addr,
 			xfer->len, req->ep_addr, done, req->sw_desc_idx,
 			req->sw_desc_cnt);
 
-#ifdef __LIBXDMA_DEBUG__
 		transfer_dump(xfer);
-#endif
 
 		rv = transfer_queue(engine, xfer);
 		if (rv < 0) {
@@ -2140,10 +2137,8 @@ ssize_t xdma_xfer_submit(void *dev_hndl, int channel, bool write, u64 ep_addr,
 				 xfer, xfer->len, req->ep_addr - xfer->len);
 			spin_unlock_irqrestore(&engine->lock, flags);
 
-#ifdef __LIBXDMA_DEBUG__
 			transfer_dump(xfer);
 			sgt_dump(sgt);
-#endif
 			rv = -EIO;
 			break;
 		default:
@@ -2156,10 +2151,8 @@ ssize_t xdma_xfer_submit(void *dev_hndl, int channel, bool write, u64 ep_addr,
 			xdma_engine_stop(engine);
 			spin_unlock_irqrestore(&engine->lock, flags);
 
-#ifdef __LIBXDMA_DEBUG__
 			transfer_dump(xfer);
 			sgt_dump(sgt);
-#endif
 			rv = -ERESTARTSYS;
 			break;
 		}

--- a/src/driver/libxdma.c
+++ b/src/driver/libxdma.c
@@ -903,7 +903,6 @@ static int map_single_bar(struct xdma_dev *xdev, struct pci_dev *dev, int idx)
 
 	/* do not map BARs with length 0. Note that start MAY be 0! */
 	if (!bar_len) {
-		//pr_info("BAR #%d is not present - skipping\n", idx);
 		return 0;
 	}
 
@@ -1961,8 +1960,6 @@ static struct xdma_request_cb * xdma_init_request(struct sg_table *sgt,
 			extra += (len + desc_blen_max - 1) / desc_blen_max;
 	}
 
-//pr_info("ep 0x%llx, desc %u+%u.\n", ep_addr, max, extra);
-
 	max += extra;
 	req = xdma_request_alloc(max);
 	if (!req)
@@ -2159,7 +2156,6 @@ ssize_t xdma_xfer_submit(void *dev_hndl, int channel, bool write, u64 ep_addr,
 			pr_info("xfer 0x%p,%u, s 0x%x timed out, ep 0x%llx.\n",
 				 xfer, xfer->len, xfer->state, req->ep_addr);
 			engine_status_read(engine, 0, 1);
-			//engine_status_dump(engine);
 			transfer_abort(engine, xfer);
 
 			xdma_engine_stop(engine);

--- a/src/driver/libxdma.h
+++ b/src/driver/libxdma.h
@@ -404,9 +404,6 @@ struct xdma_engine {
 	/* Transfer list management */
 	struct list_head transfer_list;	/* queue of transfers */
 
-	u8 *perf_buf_virt;
-	dma_addr_t perf_buf_bus; /* bus address */
-
 	int rx_tail;	/* follows the HW */
 	int rx_head;	/* where the SW reads from */
 	int rx_overrun;	/* flag if overrun occured */
@@ -422,10 +419,6 @@ struct xdma_engine {
 	struct mutex desc_lock;		/* protects concurrent access */
 	dma_addr_t desc_bus;
 	struct xdma_desc *desc;
-
-	/* for performance test support */
-	struct xdma_performance_ioctl *xdma_perf;	/* perf test control */
-	wait_queue_head_t xdma_perf_wq;	/* Perf test sync */
 };
 
 /* XDMA PCIe device specific book-keeping */

--- a/src/driver/libxdma.h
+++ b/src/driver/libxdma.h
@@ -458,22 +458,6 @@ static inline int xdma_device_flag_check(struct xdma_dev *xdev, unsigned int f)
 	return 0;
 }
 
-static inline int xdma_device_flag_test_n_set(struct xdma_dev *xdev,
-					 unsigned int f)
-{
-	unsigned long flags;
-	int rv = 0;
-
-	spin_lock_irqsave(&xdev->lock, flags);
-	if (xdev->flags & f) {
-		spin_unlock_irqrestore(&xdev->lock, flags);
-		rv = 1;
-	} else
-		xdev->flags |= f;
-	spin_unlock_irqrestore(&xdev->lock, flags);
-	return rv;
-}
-
 static inline void xdma_device_flag_set(struct xdma_dev *xdev, unsigned int f)
 {
 	unsigned long flags;

--- a/src/driver/libxdma.h
+++ b/src/driver/libxdma.h
@@ -390,7 +390,6 @@ struct xdma_engine {
 	int device_open;	/* flag if engine node open, ST mode only */
 	int running;		/* flag if the driver started engine */
 	int non_incr_addr;	/* flag if non-incremental addressing used */
-	int streaming;
 	int addr_align;		/* source/dest alignment in bytes */
 	int len_granularity;	/* transfer length multiple */
 	int addr_bits;		/* HW datapath address width */

--- a/src/driver/libxdma.h
+++ b/src/driver/libxdma.h
@@ -387,14 +387,11 @@ struct xdma_engine {
 	/* Engine state, configuration and flags */
 	enum shutdown_state shutdown;	/* engine shutdown mode */
 	enum dma_data_direction dir;
-	int device_open;	/* flag if engine node open, ST mode only */
 	int running;		/* flag if the driver started engine */
 	int non_incr_addr;	/* flag if non-incremental addressing used */
 	int addr_align;		/* source/dest alignment in bytes */
 	int len_granularity;	/* transfer length multiple */
-	int addr_bits;		/* HW datapath address width */
 	int channel;		/* engine indices */
-	int max_extra_adj;	/* descriptor prefetch capability */
 	int desc_dequeued;	/* num descriptors of completed transfers */
 	u32 status;		/* last known status of device */
 	/* only used for MSIX mode to store per-engine interrupt mask value */
@@ -403,16 +400,9 @@ struct xdma_engine {
 	/* Transfer list management */
 	struct list_head transfer_list;	/* queue of transfers */
 
-	int rx_tail;	/* follows the HW */
-	int rx_head;	/* where the SW reads from */
-	int rx_overrun;	/* flag if overrun occured */
-
 	/* Members associated with interrupt mode support */
-	wait_queue_head_t shutdown_wq;	/* wait queue for shutdown sync */
 	spinlock_t lock;		/* protects concurrent access */
-	int prev_cpu;			/* remember CPU# of (last) locker */
 	int msix_irq_line;		/* MSI-X vector for this engine */
-	u32 irq_bitmask;		/* IRQ bit mask for this engine */
 	struct work_struct work;	/* Work queue for interrupt handling */
 
 	struct mutex desc_lock;		/* protects concurrent access */
@@ -445,22 +435,14 @@ struct xdma_dev {
 	int h2c_channel_max;
 
 	/* Interrupt management */
-	int irq_count;		/* interrupt counter */
 	int irq_line;		/* flag if irq allocated successfully */
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4,12,0)
 	struct msix_entry entry[32];	/* msi-x vector/entry table */
 #endif
 
 	/* XDMA engine management */
-	int engines_num;	/* Total engine count */
-	u32 mask_irq_h2c;
-	u32 mask_irq_c2h;
 	struct xdma_engine engine_h2c[XDMA_CHANNEL_NUM_MAX];
 	struct xdma_engine engine_c2h[XDMA_CHANNEL_NUM_MAX];
-
-	/* SD_Accel specific */
-	enum dev_capabilities capabilities;
-	u64 feature_id;
 };
 
 static inline int xdma_device_flag_check(struct xdma_dev *xdev, unsigned int f)

--- a/src/driver/libxdma.h
+++ b/src/driver/libxdma.h
@@ -165,27 +165,6 @@
 /* obtain the 32 least significant (low) bits of a 32-bit or 64-bit address */
 #define PCI_DMA_L(addr) (addr & 0xffffffffUL)
 
-#ifdef __LIBXDMA_DEBUG__
-#define dbg_io		pr_err
-#define dbg_fops	pr_err
-#define dbg_perf	pr_err
-#define dbg_sg		pr_err
-#define dbg_tfr		pr_err
-#define dbg_irq		pr_err
-#define dbg_init	pr_err
-#define dbg_desc	pr_err
-#else
-/* disable debugging */
-#define dbg_io(...)
-#define dbg_fops(...)
-#define dbg_perf(...)
-#define dbg_sg(...)
-#define dbg_tfr(...)
-#define dbg_irq(...)
-#define dbg_init(...)
-#define dbg_desc(...)
-#endif
-
 /* SECTION: Enum definitions */
 enum transfer_state {
 	TRANSFER_STATE_NEW = 0,

--- a/src/driver/libxdma.h
+++ b/src/driver/libxdma.h
@@ -377,8 +377,6 @@ struct xdma_engine {
 	struct xdma_dev *xdev;	/* parent device */
 	char name[5];		/* name of this engine */
 	int version;		/* version of this engine */
-	//dev_t cdevno;		/* character device major:minor */
-	//struct cdev cdev;	/* character device (embedded struct) */
 
 	/* HW register address offsets */
 	struct engine_regs *regs;		/* Control reg BAR offset */

--- a/src/driver/xdma_sgdma.c
+++ b/src/driver/xdma_sgdma.c
@@ -79,23 +79,23 @@ static int check_transfer_align(struct xdma_engine *engine,
 		size_t len_lsb = count & ((size_t)engine->len_granularity - 1);
 		int pos_lsb = (int)pos & (engine->addr_align - 1);
 
-		dbg_tfr("AXI ST or MM non-incremental\n");
-		dbg_tfr("buf_lsb = %d, pos_lsb = %d, len_lsb = %ld\n", buf_lsb,
+		pr_debug("AXI ST or MM non-incremental\n");
+		pr_debug("buf_lsb = %d, pos_lsb = %d, len_lsb = %ld\n", buf_lsb,
 			pos_lsb, len_lsb);
 
 		if (buf_lsb != 0) {
-			dbg_tfr("FAIL: non-aligned buffer address %p\n", buf);
+			pr_debug("FAIL: non-aligned buffer address %p\n", buf);
 			return -EINVAL;
 		}
 
 		if ((pos_lsb != 0) && (sync)) {
-			dbg_tfr("FAIL: non-aligned AXI MM FPGA addr 0x%llx\n",
+			pr_debug("FAIL: non-aligned AXI MM FPGA addr 0x%llx\n",
 				(unsigned long long)pos);
 			return -EINVAL;
 		}
 
 		if (len_lsb != 0) {
-			dbg_tfr("FAIL: len %d is not a multiple of %d\n",
+			pr_debug("FAIL: len %d is not a multiple of %d\n",
 				(int)count,
 				(int)engine->len_granularity);
 			return -EINVAL;
@@ -106,8 +106,8 @@ static int check_transfer_align(struct xdma_engine *engine,
 		int pos_lsb = (int)pos & (engine->addr_align - 1);
 
 		if (buf_lsb != pos_lsb) {
-			dbg_tfr("FAIL: Misalignment error\n");
-			dbg_tfr("host addr %p, FPGA addr 0x%llx\n", buf, pos);
+			pr_debug("FAIL: Misalignment error\n");
+			pr_debug("host addr %p, FPGA addr 0x%llx\n", buf, pos);
 			return -EINVAL;
 		}
 	}

--- a/src/driver/xdma_sgdma.h
+++ b/src/driver/xdma_sgdma.h
@@ -28,18 +28,6 @@
 #include <linux/ioctl.h>
 #include "hermes_mod.h"
 
-struct xdma_performance_ioctl {
-	/* IOCTL_XDMA_IOCTL_Vx */
-	uint32_t version;
-	uint32_t transfer_size;
-	/* measurement */
-	uint32_t stopped;
-	uint32_t iterations;
-	uint64_t clock_cycle_count;
-	uint64_t data_cycle_count;
-	uint64_t pending_count;
-};
-
 int hpdev_init_channels(struct hermes_pci_dev *hpdev);
 ssize_t xdma_channel_read_write(struct xdma_channel *chnl,
 		struct iov_iter *iter, loff_t pos);


### PR DESCRIPTION
Continue cleaning up the XDMA driver by removing more unused code and reorganizing it a bit.

This PR depends on #26 and #27 and starts on d96057f ("driver: cleanup: remove remaining performance testing code"). I'll rebase when those get in.