### PR TITLE
Split XDMA and interrupt setup/teardown

### DIFF
--- a/src/driver/hermes_mod.c
+++ b/src/driver/hermes_mod.c
@@ -55,6 +55,32 @@ static const struct pci_device_id pci_ids[] = {
 };
 MODULE_DEVICE_TABLE(pci, pci_ids);
 
+static void disable_msi_msix(struct pci_dev *pdev)
+{
+	pci_disable_msix(pdev);
+}
+
+static int enable_msi_msix(struct xdma_dev *xdev)
+{
+	struct pci_dev *pdev = xdev->pdev;
+	int rv, req_nvec;
+
+	if (unlikely(!xdev || !pdev)) {
+		pr_err("xdev 0x%p, pdev 0x%p.\n", xdev, pdev);
+		return -EINVAL;
+	}
+
+	req_nvec = xdev->c2h_channel_max + xdev->h2c_channel_max;
+
+	pr_debug("Enabling MSI-X\n");
+	rv = pci_alloc_irq_vectors(pdev, req_nvec, req_nvec,
+				PCI_IRQ_MSIX);
+	if (rv < 0)
+		pr_debug("Couldn't enable MSI-X mode: %d\n", rv);
+
+	return rv;
+}
+
 static void hpdev_free(struct hermes_pci_dev *hpdev)
 {
 	struct xdma_dev *xdev = hpdev->xdev;
@@ -154,6 +180,14 @@ static int probe_one(struct pci_dev *pdev, const struct pci_device_id *id)
 	if (rv)
 		goto err_out;
 
+	rv = enable_msi_msix(xdev);
+	if (rv < 0)
+		goto err_enable_msix;
+
+	rv = xdma_irq_setup(xdev);
+	if (rv < 0)
+		goto err_interrupts;
+
 	init_ida_wq(&hpdev->c2h_ida_wq, hpdev->c2h_channel_max - 1);
 	init_ida_wq(&hpdev->h2c_ida_wq, hpdev->h2c_channel_max - 1);
 
@@ -161,6 +195,10 @@ static int probe_one(struct pci_dev *pdev, const struct pci_device_id *id)
 
 	return 0;
 
+err_interrupts:
+	xdma_irq_teardown(xdev);
+err_enable_msix:
+	disable_msi_msix(pdev);
 err_out:
 	pr_err("pdev 0x%p, err %d.\n", pdev, rv);
 	hpdev_free(hpdev);
@@ -177,6 +215,9 @@ static void remove_one(struct pci_dev *pdev)
 	hpdev = dev_get_drvdata(&pdev->dev);
 	if (!hpdev)
 		return;
+
+	xdma_irq_teardown(hpdev->xdev);
+	disable_msi_msix(pdev);
 
 	hermes_cdev_destroy(hpdev);
 	pr_info("pdev 0x%p, xdev 0x%p, 0x%p.\n",
@@ -198,6 +239,7 @@ static pci_ers_result_t xdma_error_detected(struct pci_dev *pdev,
 		pr_warn("dev 0x%p,0x%p, frozen state error, reset controller\n",
 			pdev, hpdev);
 		xdma_device_offline(pdev, hpdev->xdev);
+		xdma_irq_teardown(hpdev->xdev);
 		pci_disable_device(pdev);
 		return PCI_ERS_RESULT_NEED_RESET;
 	case pci_channel_io_perm_failure:
@@ -222,6 +264,7 @@ static pci_ers_result_t xdma_slot_reset(struct pci_dev *pdev)
 	pci_restore_state(pdev);
 	pci_save_state(pdev);
 	xdma_device_online(pdev, hpdev->xdev);
+	xdma_irq_setup(hpdev->xdev);
 
 	return PCI_ERS_RESULT_RECOVERED;
 }

--- a/src/driver/libxdma.c
+++ b/src/driver/libxdma.c
@@ -1327,7 +1327,7 @@ static void irq_teardown(struct xdma_dev *xdev)
 	irq_msix_channel_teardown(xdev);
 }
 
-static int irq_setup(struct xdma_dev *xdev)
+static int xdma_irq_setup(struct xdma_dev *xdev)
 {
 	int rv;
 	pci_keep_intx_enabled(xdev->pdev);
@@ -2433,7 +2433,7 @@ void *xdma_device_open(const char *mname, struct pci_dev *pdev,
 	if (rv < 0)
 		goto err_enable_msix;
 
-	rv = irq_setup(xdev);
+	rv = xdma_irq_setup(xdev);
 	if (rv < 0)
 		goto err_interrupts;
 
@@ -2599,7 +2599,7 @@ pr_info("pdev 0x%p, xdev 0x%p.\n", pdev, xdev);
 		}
 	}
 
-	irq_setup(xdev);
+	xdma_irq_setup(xdev);
 
 	channel_interrupts_enable(xdev);
 	read_interrupts(xdev);

--- a/src/driver/libxdma.c
+++ b/src/driver/libxdma.c
@@ -249,22 +249,24 @@ static void check_nonzero_interrupt_status(struct xdma_dev *xdev)
 			dev_name(&xdev->pdev->dev), xdev->idx, w);
 }
 
-/* channel_interrupts_enable -- Enable interrupts we are interested in */
-static void channel_interrupts_enable(struct xdma_dev *xdev)
+static void channel_interrupts_mask(struct xdma_dev *xdev, u32 mask)
 {
 	struct interrupt_regs *reg = (struct interrupt_regs *)
 		(xdev->bar[xdev->config_bar_idx] + XDMA_OFS_INT_CTRL);
 
-	write_register(~0, &reg->channel_int_enable_w1s, XDMA_OFS_INT_CTRL);
+	write_register(mask, &reg->channel_int_enable, XDMA_OFS_INT_CTRL);
+}
+
+/* channel_interrupts_enable -- Enable interrupts we are interested in */
+static void channel_interrupts_enable(struct xdma_dev *xdev)
+{
+	channel_interrupts_mask(xdev, ~0);
 }
 
 /* channel_interrupts_disable -- Disable interrupts we not interested in */
 static void channel_interrupts_disable(struct xdma_dev *xdev)
 {
-	struct interrupt_regs *reg = (struct interrupt_regs *)
-		(xdev->bar[xdev->config_bar_idx] + XDMA_OFS_INT_CTRL);
-
-	write_register(~0, &reg->channel_int_enable_w1c, XDMA_OFS_INT_CTRL);
+	channel_interrupts_mask(xdev, 0);
 }
 
 /* read_interrupts -- Print the interrupt controller status */

--- a/src/driver/libxdma.c
+++ b/src/driver/libxdma.c
@@ -1250,7 +1250,7 @@ static void prog_irq_msix_channel(struct xdma_dev *xdev, bool clear)
 	}
 }
 
-static void irq_msix_channel_teardown(struct xdma_dev *xdev)
+static void xdma_irq_teardown(struct xdma_dev *xdev)
 {
 	struct xdma_engine *engine;
 	int j = 0;
@@ -1320,11 +1320,6 @@ static int irq_msix_channel_setup(struct xdma_dev *xdev)
 	}
 
 	return 0;
-}
-
-static void irq_teardown(struct xdma_dev *xdev)
-{
-	irq_msix_channel_teardown(xdev);
 }
 
 static int xdma_irq_setup(struct xdma_dev *xdev)
@@ -2449,7 +2444,7 @@ void *xdma_device_open(const char *mname, struct pci_dev *pdev,
 	return (void *)xdev;
 
 err_interrupts:
-	irq_teardown(xdev);
+	xdma_irq_teardown(xdev);
 err_enable_msix:
 	disable_msi_msix(pdev);
 err_engines:
@@ -2490,7 +2485,7 @@ void xdma_device_close(struct pci_dev *pdev, void *dev_hndl)
 	channel_interrupts_disable(xdev);
 	read_interrupts(xdev);
 
-	irq_teardown(xdev);
+	xdma_irq_teardown(xdev);
 	disable_msi_msix(pdev);
 
 	remove_engines(xdev);
@@ -2559,7 +2554,7 @@ void xdma_device_offline(struct pci_dev *pdev, void *dev_hndl)
 	/* turn off interrupts */
 	channel_interrupts_disable(xdev);
 	read_interrupts(xdev);
-	irq_teardown(xdev);
+	xdma_irq_teardown(xdev);
 
 	pr_info("xdev 0x%p, done.\n", xdev);
 }

--- a/src/driver/libxdma.h
+++ b/src/driver/libxdma.h
@@ -498,4 +498,7 @@ void xdma_device_close(struct pci_dev *pdev, void *dev_handle);
  */
 ssize_t xdma_xfer_submit(void *dev_hndl, int channel, bool write, u64 ep_addr,
 			struct sg_table *sgt, bool dma_mapped, int timeout_ms);
+
+void xdma_irq_teardown(struct xdma_dev *xdev);
+int xdma_irq_setup(struct xdma_dev *xdev);
 #endif /* XDMA_LIB_H */


### PR DESCRIPTION
PR #23 requires setting up interrupts for the eBPF engines. However, the XDMA and interrupt setup/teardown were tied together, so adding the eBPF interrupts would have been awkward/hacky.

This PR cleans that up by moving all the interrupt setup/teardown out of XDMA functions and files into hermes_mod.c.