### PR TITLE
driver: drop support for older kernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ should threfore work for both the QEMU model and the AWS F1 instance
 noted above. This code is hosted in this repo initially and
 ideally will be upstreamed into the [Linux kernel][7].
 
+The driver requires kernel version 4.14 or higher.
+
 ## eBPF Userspace Library
 
 This part of the project implements a userspace library that provides

--- a/src/driver/hermes_mod.c
+++ b/src/driver/hermes_mod.c
@@ -234,37 +234,6 @@ static void xdma_error_resume(struct pci_dev *pdev)
 	pci_cleanup_aer_uncorrect_error_status(pdev);
 }
 
-#if KERNEL_VERSION(4, 13, 0) <= LINUX_VERSION_CODE
-static void xdma_reset_prepare(struct pci_dev *pdev)
-{
-	struct hermes_pci_dev *hpdev = dev_get_drvdata(&pdev->dev);
-
-	pr_info("dev 0x%p,0x%p.\n", pdev, hpdev);
-	xdma_device_offline(pdev, hpdev->xdev);
-}
-
-static void xdma_reset_done(struct pci_dev *pdev)
-{
-	struct hermes_pci_dev *hpdev = dev_get_drvdata(&pdev->dev);
-
-	pr_info("dev 0x%p,0x%p.\n", pdev, hpdev);
-	xdma_device_online(pdev, hpdev->xdev);
-}
-
-#elif KERNEL_VERSION(3, 16, 0) <= LINUX_VERSION_CODE
-static void xdma_reset_notify(struct pci_dev *pdev, bool prepare)
-{
-	struct hermes_pci_dev *hpdev = dev_get_drvdata(&pdev->dev);
-
-	pr_info("dev 0x%p,0x%p, prepare %d.\n", pdev, hpdev, prepare);
-
-	if (prepare)
-		xdma_device_offline(pdev, hpdev->xdev);
-	else
-		xdma_device_online(pdev, hpdev->xdev);
-}
-#endif
-
 static int __ida_wq_get(struct ida_wq *ida_wq, int *id)
 {
 	int ret;
@@ -297,12 +266,6 @@ static const struct pci_error_handlers xdma_err_handler = {
 	.error_detected	= xdma_error_detected,
 	.slot_reset	= xdma_slot_reset,
 	.resume		= xdma_error_resume,
-#if KERNEL_VERSION(4, 13, 0) <= LINUX_VERSION_CODE
-	.reset_prepare	= xdma_reset_prepare,
-	.reset_done	= xdma_reset_done,
-#elif KERNEL_VERSION(3, 16, 0) <= LINUX_VERSION_CODE
-	.reset_notify	= xdma_reset_notify,
-#endif
 };
 
 static inline struct xdma_channel *xdma_get_chnl(struct xdma_channel *channels,

--- a/src/driver/libxdma.c
+++ b/src/driver/libxdma.c
@@ -2396,11 +2396,6 @@ static int probe_engines(struct xdma_dev *xdev)
 	return 0;
 }
 
-static void pci_enable_capability(struct pci_dev *pdev, int cap)
-{
-	pcie_capability_set_word(pdev, PCI_EXP_DEVCTL, cap);
-}
-
 void *xdma_device_open(const char *mname, struct pci_dev *pdev,
 			int *h2c_channel_max, int *c2h_channel_max)
 {
@@ -2436,11 +2431,9 @@ void *xdma_device_open(const char *mname, struct pci_dev *pdev,
 	/* keep INTx enabled */
 	pci_check_intr_pend(pdev);
 
-	/* enable relaxed ordering */
-	pci_enable_capability(pdev, PCI_EXP_DEVCTL_RELAX_EN);
-
-	/* enable extended tag */
-	pci_enable_capability(pdev, PCI_EXP_DEVCTL_EXT_TAG);
+	/* enable relaxed ordering and extended tag */
+	pcie_capability_set_word(pdev, PCI_EXP_DEVCTL,
+			PCI_EXP_DEVCTL_RELAX_EN | PCI_EXP_DEVCTL_EXT_TAG);
 
 	/* force MRRS to be 512 */
 	rv = pcie_set_readrq(pdev, 512);

--- a/src/driver/libxdma.c
+++ b/src/driver/libxdma.c
@@ -1214,19 +1214,9 @@ static int enable_msi_msix(struct xdma_dev *xdev, struct pci_dev *pdev)
 	if (msi_msix_capable(pdev, PCI_CAP_ID_MSIX)) {
 		int req_nvec = xdev->c2h_channel_max + xdev->h2c_channel_max;
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 		pr_debug("Enabling MSI-X\n");
 		rv = pci_alloc_irq_vectors(pdev, req_nvec, req_nvec,
 					PCI_IRQ_MSIX);
-#else
-		int i;
-
-		pr_debug("Enabling MSI-X\n");
-		for (i = 0; i < req_nvec; i++)
-			xdev->entry[i].entry = i;
-
-		rv = pci_enable_msix(pdev, xdev->entry, req_nvec);
-#endif
 		if (rv < 0)
 			pr_debug("Couldn't enable MSI-X mode: %d\n", rv);
 	} else {
@@ -1339,11 +1329,7 @@ static int irq_msix_channel_setup(struct xdma_dev *xdev)
 	j = xdev->h2c_channel_max;
 	engine = xdev->engine_h2c;
 	for (i = 0; i < xdev->h2c_channel_max; i++, engine++) {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 		vector = pci_irq_vector(xdev->pdev, i);
-#else
-		vector = xdev->entry[i].vector;
-#endif
 		rv = request_irq(vector, xdma_channel_irq, 0, xdev->mod_name,
 				 engine);
 		if (rv) {
@@ -1357,11 +1343,7 @@ static int irq_msix_channel_setup(struct xdma_dev *xdev)
 
 	engine = xdev->engine_c2h;
 	for (i = 0; i < xdev->c2h_channel_max; i++, j++, engine++) {
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,12,0)
 		vector = pci_irq_vector(xdev->pdev, j);
-#else
-		vector = xdev->entry[j].vector;
-#endif
 		rv = request_irq(vector, xdma_channel_irq, 0, xdev->mod_name,
 				 engine);
 		if (rv) {
@@ -2414,25 +2396,10 @@ static int probe_engines(struct xdma_dev *xdev)
 	return 0;
 }
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(3,5,0)
 static void pci_enable_capability(struct pci_dev *pdev, int cap)
 {
 	pcie_capability_set_word(pdev, PCI_EXP_DEVCTL, cap);
 }
-#else
-static void pci_enable_capability(struct pci_dev *pdev, int cap)
-{
-	u16 v;
-	int pos;
-
-	pos = pci_pcie_cap(pdev);
-	if (pos > 0) {
-		pci_read_config_word(pdev, pos + PCI_EXP_DEVCTL, &v);
-		v |= cap;
-		pci_write_config_word(pdev, pos + PCI_EXP_DEVCTL, v);
-	}
-}
-#endif
 
 void *xdma_device_open(const char *mname, struct pci_dev *pdev,
 			int *h2c_channel_max, int *c2h_channel_max)

--- a/src/driver/libxdma.h
+++ b/src/driver/libxdma.h
@@ -36,6 +36,10 @@
 #include <linux/pci.h>
 #include <linux/workqueue.h>
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 0)
+#error The Hermes driver requires Linux 4.14+
+#endif
+
 /*
  * if the config bar is fixed, the driver does not neeed to search through
  * all of the bars
@@ -413,9 +417,6 @@ struct xdma_dev {
 
 	/* Interrupt management */
 	int irq_line;		/* flag if irq allocated successfully */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(4,12,0)
-	struct msix_entry entry[32];	/* msi-x vector/entry table */
-#endif
 
 	/* XDMA engine management */
 	struct xdma_engine engine_h2c[XDMA_CHANNEL_NUM_MAX];


### PR DESCRIPTION
With #ifdef's for kernels 3.5, 3.16, 4.12, 4.13, the code was getting a
bit of maintenance pain. Popular distros (Ubuntu 18.04/20.04 and
CentOS/RHEL 8) already use kernels above 4.13, so the chance of those
macros being useful is diminished.

A notable exception is RHEL/CentOS 7, which is still on 3.10 and will
thus no longer be supported.

We keep only one LINUX_VERSION_CODE macro, for 5.1.0, as that is
required to support RHEL/CentOS 8.