### PR TITLE
specs: Increase EHCMDCTRL size

### DIFF
--- a/specs/eid-hermes-interface.md
+++ b/specs/eid-hermes-interface.md
@@ -53,16 +53,16 @@ commands.
 | ...                    | ...    | ...          | ...  | ...   | ... |
 | 0x1000 + (EHENG-1)\*48 | 32     | EHCMDREQN-1  | RW   | NA    | Command Request for engine N-1 |
 | 0x1020 + (EHENG-1)\*48 | 16     | EHCMDRESN-1  | RO   | NA    | Command Response for engine N-1 |
-| 0x2000                 | 1      | EHCMDCTRL0   | RW   | NA    | Command control for request 0. See EHCMDCTRL table for details |
+| 0x2000                 | 8      | EHCMDCTRL0   | RW   | NA    | Command control for request 0. See EHCMDCTRL table for details |
 | ...                    | ...    | ...          | ...  | ...   | ... |
-| 0x2000 + (EHENG-1)     | 1      | EHCMDCTRLN-1 | RW   | NA    | Command control for request N-1. See EHCMDCTRL table for details |
+| 0x2000 + (EHENG-1)\*8  | 8      | EHCMDCTRLN-1 | RW   | NA    | Command control for request N-1. See EHCMDCTRL table for details |
 
 #### EHCMDCTRL
-| Bit | Name      | Mode | Description |
-|-----|-----------|------|-------------|
-|  0  | EHCMDEXEC | RW   | Host writes 1 to start command. Device clears after command finishes |
-|  1  | EHCMDDONE | RO   | Indicates if command has finished. Cleared by device before starting command, set when done |
-| 2-7 | --        | --   | Reserved |
+| Byte | Name      | Mode | Description |
+|------|-----------|------|-------------|
+| 0    | EHCMDEXEC | RW   | Host writes 1 to start command. Device clears after command finishes |
+| 1    | EHCMDDONE | RO   | Indicates if command has finished. Cleared by device before starting command, set when done |
+| 2-7  | --        | --   | Reserved |
 
 ## BAR2 Layout
 


### PR DESCRIPTION
Instead of using a single byte for EHCMDCTRL and giving each bit a
different meaning, just make that register wider so that each
sub-register can take a full byte.