### PR TITLE
specs: include program length on command request

### DIFF
--- a/specs/eid-hermes-commands-format.md
+++ b/specs/eid-hermes-commands-format.md
@@ -164,10 +164,12 @@ This command may return the following status:
 
 This command executes a pre-loaded eBPF program against a pre-loaded data slot.
 
-| Bytes | Description     |
-|-------|-----------------|
-| 08    | Program Slot ID |
-| 09    | Data Slot ID    |
+| Bytes | Description                |
+|-------|----------------------------|
+| 08    | Program Slot ID            |
+| 09    | Data Slot ID               |
+| 10:11 | Reserved                   |
+| 12:15 | Program Length (in bytes) |
 
 **Table 11: Run Program Command Request**
 


### PR DESCRIPTION
An eBPF program can use just part of a program slot and the eBPF engine
currently has no way of knowing its length.

This can be a problem if, for example, the eBPF engine tries to validate
if a program is valid. For example, in uBPF, the [validate()
function][1] needs the number of instructions in the program.

A simple solution is to add the program length to the command request.

An alternative would be to modify the XDMA engine to store the program
length if it the XDMA target address is in a program slot, but this
would be much more complicated.

[1]: https://github.com/iovisor/ubpf/blob/0014f298be3e2a636fd6243908238fb027527e28/vm/ubpf_vm.c#L566