### PR TITLE
bugfix: Increase slot-offsets to 64-bits

### DIFF
--- a/specs/eid-hermes-interface.md
+++ b/specs/eid-hermes-interface.md
@@ -39,15 +39,15 @@ commands.
 
 |Offset                  | Length | Name         | Mode | Value | Description            |
 |------------------------|--------|--------------|------|-------|------------------------|
-| 0x00                   | 4      | EHVER        | RO   | 1     | Interface version      |
+| 0x00                   | 4      | EHVER        | RO   | 2     | Interface version      |
 | 0x04                   | 48     | EHBLD        | RO   | NA    | Build version (git describe) |
 | 0x34                   | 1      | EHENG        | RO   | NA    | Number of eBPF Engines |
 | 0x35                   | 1      | EHPSLOT      | RO   | NA    | Number of program slots |
 | 0x36                   | 1      | EHDSLOT      | RO   | NA    | Number of data slots |
-| 0x38                   | 4      | EHPSOFF      | RO   | NA    | Base address in BAR4 of eBPF program slots |
-| 0x3C                   | 4      | EHPSSZE      | RO   | NA    | Size of a single program slot |
-| 0x40                   | 4      | EHDSOFF      | RO   | NA    | Base address in BAR4 of eBPF data slots |
-| 0x44                   | 4      | EHDSSZE      | RO   | NA    | Size of a single data slot |
+| 0x38                   | 8      | EHPSOFF      | RO   | NA    | Base address in BAR4 of eBPF program slots |
+| 0x40                   | 4      | EHPSSZE      | RO   | NA    | Size of a single program slot |
+| 0x44                   | 8      | EHDSOFF      | RO   | NA    | Base address in BAR4 of eBPF data slots |
+| 0x4C                   | 4      | EHDSSZE      | RO   | NA    | Size of a single data slot |
 | 0x1000                 | 32     | EHCMDREQ0    | RW   | NA    | Command Request for engine 0 |
 | 0x1020                 | 16     | EHCMDRES0    | RO   | NA    | Command Response for engine 0 |
 | ...                    | ...    | ...          | ...  | ...   | ... |

--- a/src/driver/hermes_cdev.c
+++ b/src/driver/hermes_cdev.c
@@ -244,7 +244,7 @@ static int hermes_read_cfg(struct hermes_pci_dev *hpdev)
 	cfg = &hpdev->hdev->cfg;
 
 	memcpy_fromio(cfg, bar0, sizeof(*cfg));
-	pr_debug("ehver: 0x%x ehbld: %s eheng: 0x%x ehpslot: 0x%x ehdslot: 0x%x ehpsoff: 0x%x ehpssze: 0x%x ehdsoff: 0x%x ehdssze: 0x%x\n",
+	pr_debug("ehver: 0x%x ehbld: %s eheng: 0x%x ehpslot: 0x%x ehdslot: 0x%x ehpsoff: 0x%llx ehpssze: 0x%x ehdsoff: 0x%llx ehdssze: 0x%x\n",
 			cfg->ehver, cfg->ehbld, cfg->eheng, cfg->ehpslot,
 			cfg->ehdslot, cfg->ehpsoff, cfg->ehpssze, cfg->ehdsoff,
 			cfg->ehdssze);

--- a/src/driver/hermes_mod.h
+++ b/src/driver/hermes_mod.h
@@ -71,9 +71,9 @@ struct __attribute__((__packed__)) hermes_cfg {
 	uint8_t ehpslot;
 	uint8_t ehdslot;
 	uint8_t rsv0;
-	uint32_t ehpsoff;
+	uint64_t ehpsoff;
 	uint32_t ehpssze;
-	uint32_t ehdsoff;
+	uint64_t ehdsoff;
 	uint32_t ehdssze;
 };
 


### PR DESCRIPTION
This resolves the 64-bit issue of #39.
Mind that this should trigger an increase of `EHVER` as it is not compatible with previous versions.