### PR TITLE
bugfix: Fix ehcmddone race-condition.

### DIFF
--- a/specs/eid-hermes-interface.md
+++ b/specs/eid-hermes-interface.md
@@ -61,7 +61,7 @@ commands.
 | Byte | Name      | Mode | Description |
 |------|-----------|------|-------------|
 | 0    | EHCMDEXEC | RW   | Host writes 1 to start command. Device clears after command finishes |
-| 1    | EHCMDDONE | RO   | Indicates if command has finished. Cleared by device before starting command, set when done |
+| 1    | EHCMDDONE | RW   | Indicates if command has finished. Cleared by host before starting command, set when done |
 | 2-7  | --        | --   | Reserved |
 
 ## BAR2 Layout

--- a/src/driver/hermes_cdev.c
+++ b/src/driver/hermes_cdev.c
@@ -147,6 +147,7 @@ static int hermes_fsync(struct file *filp, loff_t start, loff_t end, int datasyn
 			cmd.req.data_slot);
 
 	memcpy_toio(&hermes->cmds[eng].req, &cmd.req, sizeof(cmd.req));
+        iowrite8(0, &hermes->cmds_ctrl[eng].ehcmddone);
 	iowrite8(1, &hermes->cmds_ctrl[eng].ehcmdexec);
 
 	res = wait_event_interruptible(hermes->irq[eng].wq,


### PR DESCRIPTION
When offloading a program after the first one, the state of Hermes causes a race condition to occour. As such, Hermes gives control back to the application before the result of the eBPF execution is transferred to the host. Ultimately, it will be the response of the previous execution that the application receives.

Setting the ehcmddone bit host-side resolves this.

Resolves #42